### PR TITLE
[feat] Api Client 구조 개선. API Error 분류

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -5,21 +5,14 @@ import { StatusBar, View } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { NavigationContainer } from '@react-navigation/native';
 import { BottomTabNavigator } from './src/app/navigation/BottomTabNavigator';
-import { initializeApiClient } from '@mockly/api';
+import { initializeApiClient } from './src/shared/api/initializeApiClient';
 import { useAuthStore } from './src/features/auth/store';
-import { API_BASE_URL } from '@env';
 import Toast, {
   BaseToast,
   type BaseToastProps,
 } from 'react-native-toast-message';
 
-initializeApiClient({
-  baseURL: API_BASE_URL || 'http://localhost:8080',
-  timeout: 30000,
-  getAuthToken: () => {
-    return useAuthStore.getState().authState?.accessToken || null;
-  },
-});
+initializeApiClient();
 
 const toastConfig = {
   success: (props: BaseToastProps) => (

--- a/apps/mobile/src/features/auth/store.ts
+++ b/apps/mobile/src/features/auth/store.ts
@@ -52,6 +52,20 @@ const saveAuthState = async (state: StoredAuthState | null): Promise<void> => {
   }
 };
 
+// 인증 상태 초기화 헬퍼 함수
+const clearAuthState = async (
+  set: (
+    partial: Partial<AuthStore> | ((state: AuthStore) => Partial<AuthStore>),
+  ) => void,
+): Promise<void> => {
+  await saveAuthState(null);
+  set({
+    user: null,
+    authState: null,
+    isAuthenticated: false,
+  });
+};
+
 // 인증 상태 불러오기
 const loadAuthState = async (): Promise<StoredAuthState | null> => {
   try {
@@ -268,12 +282,7 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
 
       if (!refreshed) {
         // 갱신 실패 시 로그아웃 처리
-        await saveAuthState(null);
-        set({
-          user: null,
-          authState: null,
-          isAuthenticated: false,
-        });
+        await clearAuthState(set);
         return false;
       }
 
@@ -291,12 +300,7 @@ export const useAuthStore = create<AuthStore>((set, get) => ({
       return true;
     } catch {
       // 갱신 실패 시 로그아웃 처리
-      await saveAuthState(null);
-      set({
-        user: null,
-        authState: null,
-        isAuthenticated: false,
-      });
+      await clearAuthState(set);
       return false;
     }
   },

--- a/apps/mobile/src/shared/api/initializeApiClient.ts
+++ b/apps/mobile/src/shared/api/initializeApiClient.ts
@@ -1,0 +1,134 @@
+import { API_BASE_URL } from '@env';
+import { useAuthStore } from '@features/auth/store';
+import {
+  initializeApiClient as initializeAxiosApiClient,
+  apiClient,
+  AxiosRequestConfig,
+} from '@mockly/api';
+import { ApiError } from '@shared/errors/ApiError';
+
+// 15초: 모바일 네트워크 환경 고려한 타임아웃
+const API_TIMEOUT = 15000;
+// 최대 토큰 갱신 재시도 횟수
+const MAX_RETRY_COUNT = 3;
+
+// 재시도 플래그가 추가된 요청 config 타입
+interface RetryableRequestConfig extends AxiosRequestConfig {
+  _retry?: boolean;
+}
+
+// 토큰 갱신 중 여부를 추적
+let isRefreshing = false;
+let retryCount = 0;
+let failedQueue: Array<{
+  resolve: (value: unknown) => void;
+  reject: (reason?: unknown) => void;
+}> = [];
+
+// 대기 중인 요청 처리
+const processQueue = (error: Error | null) => {
+  failedQueue.forEach(promise => {
+    if (error) {
+      promise.reject(error);
+    } else {
+      // resolve(null) 후 .then()에서 apiClient.client()로 실제 요청 재시도
+      promise.resolve(null);
+    }
+  });
+  failedQueue = [];
+};
+
+export const initializeApiClient = () =>
+  initializeAxiosApiClient({
+    baseURL: API_BASE_URL || 'http://localhost:8080',
+    timeout: API_TIMEOUT,
+    requestInterceptor: async config => {
+      const accessToken = useAuthStore.getState().authState?.accessToken;
+      if (accessToken) {
+        config.headers.Authorization = `Bearer ${accessToken}`;
+      }
+      return config;
+    },
+    responseErrorInterceptor: async error => {
+      const originalRequest = error.config as RetryableRequestConfig;
+
+      // 401 에러가 아니거나 이미 재시도한 경우
+      if (error.response?.status !== 401 || originalRequest?._retry) {
+        throw ApiError.fromAxiosError(error);
+      }
+
+      const apiError = ApiError.fromAxiosError(error);
+
+      // 토큰 갱신이 필요하지 않은 경우
+      if (!apiError.shouldRefreshToken) {
+        // 재로그인이 필요한 경우 로그아웃 처리
+        if (apiError.shouldReLogin) {
+          await useAuthStore.getState().signOut();
+        }
+        throw apiError;
+      }
+
+      // 토큰 갱신이 필요한 경우
+      if (isRefreshing) {
+        // 최대 재시도 횟수 초과 시 로그아웃
+        if (retryCount >= MAX_RETRY_COUNT) {
+          await useAuthStore.getState().signOut();
+          throw new Error('최대 재시도 횟수를 초과했습니다');
+        }
+        retryCount++;
+        // 이미 갱신 중이면 대기열에 추가
+        return new Promise((resolve, reject) => {
+          failedQueue.push({ resolve, reject });
+        })
+          .then(() => {
+            // 갱신 완료 후 재시도
+            const newToken = useAuthStore.getState().authState?.accessToken;
+            if (originalRequest && originalRequest.headers && newToken) {
+              originalRequest.headers.Authorization = `Bearer ${newToken}`;
+            }
+            return apiClient.client(originalRequest!);
+          })
+          .catch(err => {
+            throw err;
+          });
+      }
+
+      // 재시도 플래그 설정
+      originalRequest._retry = true;
+      isRefreshing = true;
+
+      try {
+        // 토큰 갱신 시도
+        const success = await useAuthStore.getState().refreshToken();
+
+        if (!success) {
+          // 갱신 실패
+          processQueue(new Error('토큰 갱신에 실패했습니다'));
+          throw apiError;
+        }
+
+        // 갱신 성공
+        const newToken = useAuthStore.getState().authState?.accessToken;
+        if (!newToken) {
+          processQueue(new Error('새 토큰을 가져올 수 없습니다'));
+          throw apiError;
+        }
+
+        // 대기 중인 요청들 처리
+        processQueue(null);
+
+        // 원래 요청에 새 토큰 적용하여 재시도
+        if (originalRequest && originalRequest.headers) {
+          originalRequest.headers.Authorization = `Bearer ${newToken}`;
+        }
+
+        return apiClient.client(originalRequest!);
+      } catch (refreshError) {
+        processQueue(refreshError as Error);
+        throw refreshError;
+      } finally {
+        isRefreshing = false;
+        retryCount = 0; // 재시도 카운터 초기화
+      }
+    },
+  });

--- a/apps/mobile/src/shared/errors/ApiError.ts
+++ b/apps/mobile/src/shared/errors/ApiError.ts
@@ -35,6 +35,19 @@ export const ERROR_CODES = {
 export type ErrorCode = (typeof ERROR_CODES)[keyof typeof ERROR_CODES];
 
 /**
+ * 에러 응답 타입 가드
+ */
+interface ErrorResponse {
+  code?: string;
+  message?: string;
+  error?: string;
+}
+
+const isErrorResponse = (data: unknown): data is ErrorResponse => {
+  return typeof data === 'object' && data !== null;
+};
+
+/**
  * HTTP Status Code별 에러 메시지 매핑
  */
 const ERROR_MESSAGES: Record<number, string> = {
@@ -128,10 +141,14 @@ export class ApiError extends Error {
     if (error.response) {
       const { status, data } = error.response;
       const serverMessage = data?.message || data?.error || null;
-      // errorCode는 response data에서 추출
-      const errorCode = (data as unknown as Record<string, unknown>)?.code as
-        | ErrorCode
-        | undefined;
+
+      // errorCode는 response data에서 타입 가드를 사용하여 안전하게 추출
+      const errorCode =
+        isErrorResponse(data) && data.code
+          ? (data.code as ErrorCode)
+          : undefined;
+
+      // 사용자에게 보여줄 메시지 결정
       const message =
         serverMessage ||
         ERROR_MESSAGES[status] ||

--- a/apps/mobile/src/shared/errors/ApiError.ts
+++ b/apps/mobile/src/shared/errors/ApiError.ts
@@ -1,0 +1,168 @@
+import { ApiResponse, AxiosError } from '@mockly/api';
+
+/**
+ * API 에러 코드 상수
+ */
+export const ERROR_CODES = {
+  // 400 Bad Request
+  BAD_REQUEST: 'BAD_REQUEST',
+
+  // 401 Unauthorized
+  EXPIRED_TOKEN: 'EXPIRED_TOKEN',
+  UNAUTHORIZED: 'UNAUTHORIZED',
+  TOKEN_REQUIRED: 'TOKEN_REQUIRED',
+  INVALID_TOKEN: 'INVALID_TOKEN',
+  INVALID_GOOGLE_TOKEN: 'INVALID_GOOGLE_TOKEN',
+
+  // 403 Forbidden
+  FORBIDDEN: 'FORBIDDEN',
+
+  // 404 Not Found
+  USER_NOT_FOUND: 'USER_NOT_FOUND',
+  RESOURCE_NOT_FOUND: 'RESOURCE_NOT_FOUND',
+
+  // 422 Unprocessable Entity
+  VALIDATION_ERROR: 'VALIDATION_ERROR',
+
+  // 네트워크 관련
+  NETWORK_ERROR: 'NETWORK_ERROR',
+  TIMEOUT_ERROR: 'TIMEOUT_ERROR',
+
+  // 알 수 없는 에러
+  UNKNOWN_ERROR: 'UNKNOWN_ERROR',
+} as const;
+
+export type ErrorCode = (typeof ERROR_CODES)[keyof typeof ERROR_CODES];
+
+/**
+ * HTTP Status Code별 에러 메시지 매핑
+ */
+const ERROR_MESSAGES: Record<number, string> = {
+  400: '잘못된 요청. 요청 파라미터를 확인하세요',
+  401: '인증이 필요합니다',
+  403: '권한이 없습니다',
+  404: '요청한 리소스를 찾을 수 없습니다',
+  422: '폼 유효성 에러',
+  500: '서버 에러가 발생했습니다',
+};
+
+/**
+ * API 에러 기본 클래스
+ */
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    public statusCode: number,
+    public errorCode?: ErrorCode,
+    public responseData?: ApiResponse<unknown>,
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+
+  /**
+   * 토큰 갱신이 필요한 경우
+   */
+  get shouldRefreshToken(): boolean {
+    return (
+      this.statusCode === 401 && this.errorCode === ERROR_CODES.EXPIRED_TOKEN
+    );
+  }
+
+  /**
+   * 재로그인이 필요한 경우
+   */
+  get shouldReLogin(): boolean {
+    return (
+      this.statusCode === 401 &&
+      (this.errorCode === ERROR_CODES.UNAUTHORIZED ||
+        this.errorCode === ERROR_CODES.TOKEN_REQUIRED ||
+        this.errorCode === ERROR_CODES.INVALID_TOKEN ||
+        this.errorCode === ERROR_CODES.INVALID_GOOGLE_TOKEN)
+    );
+  }
+
+  /**
+   * 네트워크 연결 에러인 경우 (타임아웃 또는 네트워크 에러)
+   */
+  get isConnectionError(): boolean {
+    return (
+      this.errorCode === ERROR_CODES.NETWORK_ERROR ||
+      this.errorCode === ERROR_CODES.TIMEOUT_ERROR
+    );
+  }
+
+  /**
+   * 권한이 없는 경우 (403 Forbidden)
+   */
+  get hasNoPermission(): boolean {
+    return this.statusCode === 403;
+  }
+
+  /**
+   * 리소스를 찾을 수 없는 경우 (404 Not Found)
+   */
+  get hasNoResource(): boolean {
+    return this.statusCode === 404;
+  }
+
+  /**
+   * 서버 에러인 경우 (500번대)
+   */
+  get isServerError(): boolean {
+    return this.statusCode >= 500 && this.statusCode < 600;
+  }
+
+  /**
+   * 일반적인 클라이언트 에러 (400, 422)
+   */
+  get isCommonError(): boolean {
+    return this.statusCode === 400 || this.statusCode === 422;
+  }
+
+  /**
+   * AxiosError를 분석하여 적절한 커스텀 에러로 변환
+   */
+  static fromAxiosError(error: AxiosError<ApiResponse<unknown>>): ApiError {
+    // HTTP 응답이 있는 경우 (4xx, 5xx 에러)
+    if (error.response) {
+      const { status, data } = error.response;
+      const serverMessage = data?.message || data?.error || null;
+      // errorCode는 response data에서 추출
+      const errorCode = (data as unknown as Record<string, unknown>)?.code as
+        | ErrorCode
+        | undefined;
+      const message =
+        serverMessage ||
+        ERROR_MESSAGES[status] ||
+        '비식별 서버 에러가 발생했습니다';
+
+      return new ApiError(message, status, errorCode, data);
+    }
+
+    // 타임아웃 에러
+    if (error.code === 'ECONNABORTED' || error.message.includes('timeout')) {
+      return new ApiError(
+        '요청 시간이 초과되었습니다',
+        0,
+        ERROR_CODES.TIMEOUT_ERROR,
+      );
+    }
+
+    // 네트워크 에러
+    if (error.message === 'Network Error' || !error.response) {
+      return new ApiError(
+        '네트워크 연결이 없습니다',
+        0,
+        ERROR_CODES.NETWORK_ERROR,
+      );
+    }
+
+    // 기타 알 수 없는 에러
+    return new ApiError(
+      '알 수 없는 서비스 오류가 발생했습니다',
+      0,
+      ERROR_CODES.UNKNOWN_ERROR,
+    );
+  }
+}

--- a/apps/mobile/src/shared/errors/index.ts
+++ b/apps/mobile/src/shared/errors/index.ts
@@ -1,0 +1,1 @@
+export * from './ApiError';

--- a/packages/api/src/client/apiClient.ts
+++ b/packages/api/src/client/apiClient.ts
@@ -1,0 +1,108 @@
+import axios, {
+  AxiosInstance,
+  AxiosRequestConfig,
+  InternalAxiosRequestConfig,
+  AxiosResponse,
+  AxiosError,
+} from 'axios';
+import { ApiResponse } from '../types';
+
+// axios 관련 타입들 재export
+export { AxiosError };
+export type { AxiosResponse, AxiosRequestConfig, AxiosInstance };
+
+export interface ApiClientConfig {
+  baseURL: string;
+  timeout?: number;
+  headers?: Record<string, string>;
+  requestInterceptor?: (
+    config: InternalAxiosRequestConfig
+  ) => InternalAxiosRequestConfig | Promise<InternalAxiosRequestConfig>;
+  requestErrorInterceptor?: (error: AxiosError) => Promise<AxiosError>;
+  responseInterceptor?: (response: AxiosResponse) => AxiosResponse | Promise<AxiosResponse>;
+  responseErrorInterceptor?: (error: AxiosError<ApiResponse>) => Promise<unknown>;
+}
+
+export class ApiClient {
+  public client: AxiosInstance;
+  private config: ApiClientConfig;
+
+  constructor(config: ApiClientConfig) {
+    this.client = axios.create({
+      baseURL: config.baseURL,
+      timeout: config.timeout || 30000,
+      headers: {
+        'Content-Type': 'application/json',
+        ...config.headers,
+      },
+    });
+    this.config = config;
+    this.setupInterceptors();
+  }
+
+  private setupInterceptors() {
+    // Request interceptor
+    this.client.interceptors.request.use(
+      this.config.requestInterceptor,
+      this.config.requestErrorInterceptor
+    );
+
+    // Response interceptor
+    this.client.interceptors.response.use(
+      this.config.responseInterceptor,
+      this.config.responseErrorInterceptor
+    );
+  }
+
+  public async get<T>(url: string, config?: AxiosRequestConfig): Promise<ApiResponse<T>> {
+    const response = await this.client.get<ApiResponse<T>>(url, config);
+    return response.data;
+  }
+
+  public async post<T>(
+    url: string,
+    data?: unknown,
+    config?: AxiosRequestConfig
+  ): Promise<ApiResponse<T>> {
+    const response = await this.client.post<ApiResponse<T>>(url, data, config);
+    return response.data;
+  }
+
+  public async put<T>(
+    url: string,
+    data?: unknown,
+    config?: AxiosRequestConfig
+  ): Promise<ApiResponse<T>> {
+    const response = await this.client.put<ApiResponse<T>>(url, data, config);
+    return response.data;
+  }
+
+  public async delete<T>(url: string, config?: AxiosRequestConfig): Promise<ApiResponse<T>> {
+    const response = await this.client.delete<ApiResponse<T>>(url, config);
+    return response.data;
+  }
+
+  public async patch<T>(
+    url: string,
+    data?: unknown,
+    config?: AxiosRequestConfig
+  ): Promise<ApiResponse<T>> {
+    const response = await this.client.patch<ApiResponse<T>>(url, data, config);
+    return response.data;
+  }
+}
+
+let _apiClient: ApiClient | null = null;
+
+export function initializeApiClient(config: ApiClientConfig): void {
+  _apiClient = new ApiClient(config);
+}
+
+export const apiClient = new Proxy({} as ApiClient, {
+  get(_target, prop) {
+    if (!_apiClient) {
+      throw new Error('API Client가 초기화되지 않았습니다.');
+    }
+    return _apiClient[prop as keyof ApiClient];
+  },
+});

--- a/packages/api/src/client/index.ts
+++ b/packages/api/src/client/index.ts
@@ -1,18 +1,1 @@
-import { ApiClient, ApiClientConfig } from './client';
-
-export { ApiClient, type ApiClientConfig } from './client';
-
-let _apiClient: ApiClient | null = null;
-
-export function initializeApiClient(config: ApiClientConfig): void {
-  _apiClient = new ApiClient(config);
-}
-
-export const apiClient = new Proxy({} as ApiClient, {
-  get(_target, prop) {
-    if (!_apiClient) {
-      throw new Error('ApiClient not initialized. Call initializeApiClient first.');
-    }
-    return _apiClient[prop as keyof ApiClient];
-  },
-});
+export * from './apiClient';

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,5 +1,5 @@
 // Export API client and domain modules
-export * from './client/index';
+export * from './client';
 export * from './types';
 export * as auth from './auth';
 export * as user from './user';

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -1,4 +1,4 @@
-export interface ApiResponse<T> {
+export interface ApiResponse<T = unknown> {
   data: T;
   error: string | null;
   message: string | null;


### PR DESCRIPTION
## 요약

API 통신의 안정성과 에러 처리를 개선하기 위해 중앙화된 API 클라이언트 시스템을 구축했습니다. 토큰 기반 인증에서 발생하는 401 에러를 자동으로 감지하여 토큰을 갱신하고 실패한 요청을 재시도하는 인터셉터를 구현했으며, 체계적인 에러 분류 및 처리를 위한 ApiError 클래스를 추가했습니다.

## 주요 변경사항

- API 클라이언트 구조 개선: 모듈화 및 타입 안정성 강화
- 커스텀 에러 처리 시스템: HTTP 상태 코드별 에러 분류 및 메시지 매핑
- 토큰 자동 갱신 메커니즘: 401 에러 발생 시 자동 토큰 갱신 및 요청 재시도
- 토큰 갱신 대기열 관리: 중복 갱신 방지 및 대기 중인 요청 효율적 처리
- 모바일 네트워크 최적화: 15초 타임아웃 및 최대 3회 재시도 제한

## 변경 내용

### API 클라이언트 구조 개선

**packages/api/src/client/apiClient.ts**
- ApiClient 클래스를 별도 파일로 분리하여 모듈화
- HTTP 메서드별 wrapper 함수 구현 (GET, POST, PUT, DELETE, PATCH)
- Request/Response Interceptor 설정 기능 추가
- AxiosError, AxiosResponse, AxiosRequestConfig 타입 재export

**packages/api/src/types.ts**
- ApiResponse 타입에 제네릭 기본값 추가 (`T = unknown`)

**packages/api/src/client/index.ts**
- 단순 재export 파일로 변경하여 코드 구조 개선

### 에러 처리 시스템

**apps/mobile/src/shared/errors/ApiError.ts**
- ApiError 클래스 구현
- ERROR_CODES 상수 정의:
  - 인증 관련: EXPIRED_TOKEN, UNAUTHORIZED, TOKEN_REQUIRED, INVALID_TOKEN
  - 네트워크 관련: NETWORK_ERROR, TIMEOUT_ERROR
  - HTTP 상태: BAD_REQUEST, FORBIDDEN, RESOURCE_NOT_FOUND 등
- HTTP 상태 코드별 에러 메시지 매핑
- AxiosError를 ApiError로 변환하는 `fromAxiosError` 정적 메서드

**에러 판단 헬퍼 메서드**
- `shouldRefreshToken`: 토큰 갱신 필요 여부 (401 + EXPIRED_TOKEN)
- `shouldReLogin`: 재로그인 필요 여부 (401 + 기타 인증 에러)
- `isConnectionError`: 네트워크 연결 에러 감지
- `hasNoPermission`: 권한 에러 (403)
- `hasNoResource`: 리소스 없음 (404)
- `isServerError`: 서버 에러 (5xx)

### 토큰 자동 갱신 및 인증

**apps/mobile/src/shared/api/initializeApiClient.ts**
- 모바일 앱 전용 API 클라이언트 초기화 함수 구현
- 모바일 네트워크 환경 고려한 타임아웃 설정 (15초)

**Request Interceptor**
- Authorization 헤더에 액세스 토큰 자동 추가

**Response Error Interceptor**
- 401 에러 감지 및 토큰 갱신 필요 여부 판단
- 토큰 갱신 중복 방지: `isRefreshing` 플래그 관리
- 대기열 처리: 갱신 중 발생한 요청들을 `failedQueue`에 추가
- 갱신 완료 후 대기 중인 모든 요청에 새 토큰 적용하여 재시도
- 최대 재시도 횟수 제한 (3회) - 무한 루프 방지
- 갱신 실패 시 자동 로그아웃 처리

**apps/mobile/src/features/auth/store.ts**
- `refreshToken` 메서드 추가
  - 기존 리프레시 토큰으로 새 액세스 토큰 발급
  - 갱신 성공 시 상태 업데이트 및 저장
  - 갱신 실패 시 로그아웃 처리

**apps/mobile/App.tsx**
- API 클라이언트 초기화 로직을 별도 모듈로 분리
- 코드 간결성 향상

## 테스트

### 수동 테스트 가이드

#### 토큰 갱신 시나리오
1. 앱 실행 및 로그인
2. 액세스 토큰 만료 시간까지 대기 (또는 수동으로 만료된 토큰 설정)
3. API 요청 실행 (예: 사용자 정보 조회)
4. 401 에러 발생 시 자동으로 토큰 갱신되는지 확인
5. 원래 요청이 새 토큰으로 재시도되어 성공하는지 확인

#### 에러 처리 시나리오
1. 네트워크 연결 끊기 → NETWORK_ERROR 표시 확인
2. 잘못된 토큰으로 요청 → 자동 로그아웃 확인
3. 권한 없는 리소스 접근 → 403 에러 처리 확인
4. 존재하지 않는 리소스 요청 → 404 에러 처리 확인

#### 동시 요청 시나리오
1. 액세스 토큰 만료 상태에서 여러 API 요청 동시 실행
2. 토큰 갱신이 한 번만 발생하는지 확인
3. 대기열에 있던 모든 요청이 성공적으로 처리되는지 확인

### 테스트 환경

- 로컬 개발 환경에서 타입 체크 통과 확인 (`turbo run type-check`)
- lint 및 prettier 자동 수정 완료
- iOS 시뮬레이터 / Android 에뮬레이터에서 동작 확인 필요

### 알려진 제약사항

- 최대 3회 토큰 갱신 재시도 후 자동 로그아웃
- 네트워크 타임아웃 15초 (모바일 환경 고려)

## 스크린샷

<!-- 에러 메시지 UI 스크린샷이 있다면 추가해주세요 -->

## 관련 이슈

- 관련 이슈가 있다면 여기에 추가

## 완료

- [x] API 클라이언트 모듈 구조 개선 및 타입 정의
- [x] ApiError 클래스 구현 및 에러 코드 상수 정의
- [x] HTTP 상태 코드별 에러 메시지 매핑
- [x] 토큰 자동 갱신 인터셉터 구현
- [x] 토큰 갱신 대기열 관리 로직 구현
- [x] auth store에 refreshToken 메서드 추가
- [x] 모바일 앱 전용 API 클라이언트 초기화 함수 작성
- [x] Request Interceptor: Authorization 헤더 자동 추가
- [x] Response Error Interceptor: 401 에러 처리 및 재시도
- [x] 타입 체크 및 lint 통과