### PR TITLE
[docs] 프로젝트 README 문서 전면 개편 및 구조 개선

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,579 +1,142 @@
 # Mockly Mobile
 
-Turborepo + pnpm workspace 기반의 React Native 모바일 애플리케이션 monorepo 프로젝트입니다.
+모던 React Native 모노레포
+Turborepo + pnpm 기반, 디자인 시스템과 Storybook을 통합한 실전 모바일 앱 프로젝트
 
-## 프로젝트 구조
+---
+
+## 📦 패키지/앱별 역할 요약
+
+- **mobile**: React Native 앱 구현 (iOS/Android), 상태관리(Zustand), 실제 앱 화면/기능 코드
+- **storybook**: 모바일/웹에서 디자인 시스템 및 화면을 실시간으로 확인/문서화
+- **design-system**: UI 컴포넌트/테마 패키지, 재사용성 강화, 시스템화된 테마/variant, tw 객체 제공
+- **api**: 백엔드 API 연동, DTO→Entity 변환, 인증/인터셉터 등 서비스 코드
+- **entities**: 실제 사용되는 도메인 엔티티 타입/인터페이스 정의
+- **utils**: time/string format 등 공통 유틸리티 함수 모음
+- **typescript-config**: tsconfig 설정 재사용 패키지 (모든 앱/패키지에서 참조)
+
+---
+
+<table>
+  <tr>
+      <td>라이트</td>
+    <td>다크</td>
+        <td>모바일 스토리북</td>
+        <td>웹 스토리북</td>
+  </tr>
+  <tr>
+    <td><image src="https://github.com/user-attachments/assets/5f3a634e-6d5f-4544-8bc6-b225bf8e3f30" style="width:300;"></image></td>
+    <td><image src="https://github.com/user-attachments/assets/e9408cb8-872a-45e4-ba31-6883f859233a" style="width:300;"></image></td>
+        <td><image src="https://github.com/user-attachments/assets/c11f1b8b-686e-435d-b64f-4a7a3818ee20" style="width:300;"></image></td>
+        <td><image src="https://github.com/user-attachments/assets/0f9f4d8a-56dc-4727-b6d5-c7bf5bd3c12e" style="width:300;">
+          <a href="https://69324aeddcbd1324310464e9-giibikyaod.chromatic.com/">디자인 시스템 보러가기</a>
+        </image></td>
+  </tr>
+</table>
+
+---
+
+## 주요 특징
+
+- Monorepo: Turborepo + pnpm workspace
+- Design System: 재사용 가능한 UI 컴포넌트 패키지
+- Storybook: 디자인 시스템 문서화 및 실시간 프리뷰
+- 상태관리: Zustand
+- 스타일링: Tailwind(twrnc) + cva + clsx + tailwind-merge
+- API/엔티티/유틸: 패키지 분리, 타입 안전성 강화
+
+## 폴더 구조
 
 ```
-mockly-mobile/
-├── apps/
-│   ├── mobile/                    # React Native 앱 (메인 애플리케이션)
-│   │   ├── src/
-│   │   │   ├── app/              # 애플리케이션 레이어 (screens, navigation, components)
-│   │   │   ├── features/         # 도메인 기능 (auth, chat 등)
-│   │   │   ├── lib/              # 라이브러리 래퍼 및 유틸리티
-│   │   │   └── shared/           # 공유 리소스 (constants, utils)
-│   │   └── __tests__/            # 테스트 파일
-│   └── storybook/                 # 디자인 시스템 문서용 Storybook
-├── packages/
-│   ├── entities/                  # 공유 TypeScript 타입과 인터페이스
-│   ├── design-system/             # 재사용 가능한 React Native 컴포넌트
-│   ├── api/                       # API 클라이언트 및 서비스 레이어
-│   ├── utils/                     # 공유 유틸리티 함수
-│   └── typescript-config/         # 공유 TypeScript 설정
-└── .env.*                         # 환경별 구성 파일
+apps/
+  mobile/      # 메인 React Native 앱
+  storybook/   # 디자인 시스템/스토리북
+packages/
+  design-system/  # UI 컴포넌트/테마
+  api/            # API 클라이언트
+  entities/       # 타입/도메인 모델
+  utils/          # 유틸리티
+  typescript-config/
 ```
 
-### 디렉토리 구조 (Feature-Sliced Design 영향)
+## 빠른 시작
 
-Mobile 앱은 계층화된 아키텍처를 따릅니다:
+### 개발 환경 사전 준비
 
-```
-src/
-├── app/                    # 애플리케이션 레이어
-│   ├── screens/           # 화면 컴포넌트
-│   ├── navigation/        # 내비게이션 설정
-│   └── components/        # 앱 전용 컴포넌트
-├── features/              # 도메인 기능
-│   └── auth/             # 인증 기능
-│       ├── hooks.ts      # useAuth 훅
-│       ├── store.ts      # Zustand 스토어
-│       ├── types.ts      # 타입 정의
-│       └── errors.ts     # 에러 정의
-├── lib/                   # 외부 라이브러리 래퍼
-│   └── app-auth/         # 인증 라이브러리
-│       ├── base/         # 추상 클래스
-│       ├── providers/    # Provider 구현체
-│       └── index.ts
-└── shared/                # 공유 리소스
-    ├── constants/        # 상수
-    └── utils/            # 유틸리티
-```
+- 앱 테스트 시 [React Native 공식 환경설정 가이드](https://reactnative.dev/docs/set-up-your-environment) 참고 (Node, Android Studio, Xcode 등 필수)
+- storybook 웹 버전은 사전 설정이 없습니다.
 
-## 주요 구성 요소
+### .env.dev 파일 필요
 
-### Apps
+- 에뮬레이터로 앱 개발시 `apps/mobile/.env.dev` 파일을 반드시 생성해야 합니다.
 
-#### mobile
-
-React Native 모바일 애플리케이션입니다.
-
-**주요 기술:**
-
-- React Native 0.82.1
-- twrnc 4.11.1 (Tailwind CSS for React Native)
-- React Native Dotenv (환경변수 관리)
-- Design System 패키지 통합
-
-**실행 방법:**
-Android Studio와 앱 에뮬레이터가 설치되어 있어야 실행 가능합니다.
-
-```bash
-# Metro bundler 시작 (개발 모드, .env.dev 사용)
-pnpm dev
-
-# Android/iOS 실행 (별도 터미널)
-cd apps/mobile
-pnpm android  # Android 실행
-pnpm ios      # iOS 실행
-```
-
-#### storybook
-
-디자인 시스템 컴포넌트를 문서화하고 테스트하는 Storybook 앱입니다.
-
-**주요 기술:**
-
-- Storybook React Native Web
-- Vite 빌더
-- Design System 컴포넌트 통합
-
-**실행 방법:**
-Android Studio와 앱 에뮬레이터가 설치되어 있어야 실행 가능합니다.
-
-```bash
-# 루트에서 실행
-pnpm storybook:web  # 웹을 통해 디자인 시스템 확인하는 방법
-
-pnpm storybook # 안드로이드로 디자인 시스템 확인하는 방법
-
-# 또는 직접 실행
-cd apps/storybook
-pnpm storybook:web
-pnpm storybook:android
-pnpm storybook:ios
-```
-
-### Packages
-
-#### @mockly/entities
-
-공통으로 사용되는 타입과 인터페이스를 정의합니다.
-
-**포함 내용:**
-
-- User 타입
-- Mock 타입
-- 기타 도메인 엔티티
-
-#### @mockly/design-system
-
-재사용 가능한 React Native 컴포넌트 라이브러리입니다.
-
-**포함 컴포넌트:**
-
-- Button
-- Text
-- Input
-
-**테마 시스템:**
-
-- `src/theme/index.ts`에서 중앙 관리
-- `twrnc` + `tailwind.config.js`로 스타일 관리
-- Colors, Spacing, Typography, BorderRadius 제공
-- Storybook에서 시각적으로 확인 가능
-
-#### @mockly/api
-
-API 통신을 위한 클라이언트와 서비스 레이어입니다.
-
-**포함 내용:**
-
-- ApiClient (Axios 기반)
-- UserService
-- MockService
-- 인터셉터 및 에러 핸들링
-
-#### @mockly/utils
-
-공유 유틸리티 함수를 제공합니다.
-
-**포함 내용:**
-
-- `cn`: classnames 유틸리티 (클래스명 병합)
-- 기타 공통 헬퍼 함수
-
-#### @mockly/typescript-config
-
-공유 TypeScript 설정 파일입니다.
-
-**포함 내용:**
-
-- base.json (기본 설정)
-- react-native.json (React Native 설정)
-
-## 환경변수 설정
-
-프로젝트는 세 가지 환경을 지원합니다:
-
-- `.env.dev`: 개발 환경
-- `.env.stage`: 스테이징 환경
-- `.env.prod`: 운영 환경
-
-### 환경변수 자동 로드
-
-- **개발 모드 (`pnpm dev`)**: `.env.dev` 자동 로드
-- **빌드 (`pnpm build:android`, `pnpm build:ios`)**: `.env.prod` 자동 로드
-- `babel.config.js`의 `react-native-dotenv` 플러그인으로 관리
-- `NODE_ENV`는 자동으로 설정되므로 수동 설정 불필요
-
-### 환경변수 파일 예시
-
-각 환경별로 `.env.*` 파일을 생성하고 필요한 환경변수를 설정하세요.
-
-```bash
-# apps/mobile/.env.dev 예시
+```env
 GOOGLE_WEB_CLIENT_ID=your_google_web_client_id
 GOOGLE_IOS_CLIENT_ID=your_google_ios_client_id
 GOOGLE_ANDROID_CLIENT_ID=your_google_android_client_id
 API_BASE_URL=http://localhost:8080
 ```
 
-### 환경변수 사용 방법
-
-```typescript
-import { API_BASE_URL, GOOGLE_WEB_CLIENT_ID } from '@env';
-
-console.log(API_BASE_URL); // http://localhost:8080
-```
-
-**주의사항:**
-
-- 민감 정보는 `.env.*` 파일에 저장하고 Git에 커밋하지 마세요
-- 서비스 초기화 시 필수 환경변수를 검증하세요
-
-## 아키텍처 패턴
-
-### Path Alias (tsconfig.json)
-
-프로젝트는 절대 경로 import를 사용합니다:
-
-```typescript
-import { AuthUser } from '@features/auth/types';
-import { GoogleAuthService } from '@lib/app-auth/providers/GoogleAuthService';
-import { HomeScreen } from '@app/screens/home/HomeScreen';
-import { API_BASE_URL } from '@env';
-import { cn } from '@mockly/utils';
-```
-
-**사용 가능한 Alias:**
-
-- `@app/*`: src/app/\* (애플리케이션 레이어)
-- `@features/*`: src/features/\* (도메인 기능)
-- `@lib/*`: src/lib/\* (라이브러리 래퍼)
-- `@shared/*`: src/shared/\* (공유 리소스)
-- `@mockly/*`: workspace 패키지
-
-### 인증 아키텍처 (Provider Pattern + PKCE)
-
-OAuth 2.0 PKCE 기반 인증을 Provider Pattern으로 구현했습니다:
-
-```
-BaseAuthService (추상 클래스)
-    ↓
-GoogleAuthService (구현체)
-AppleAuthService (구현체)
-    ↓
-getAuthService(provider) (Factory)
-    ↓
-useAuthStore (Zustand)
-    ↓
-useAuth (Custom Hook)
-```
-
-**주요 특징:**
-
-- PKCE (Proof Key for Code Exchange) 기반 보안
-- Provider 패턴으로 확장 가능한 구조
-- Zustand로 전역 상태 관리
-- Custom Hook으로 캡슐화
-
-### 컴포넌트 패턴 (cva + tw)
-
-디자인 시스템 컴포넌트는 `class-variance-authority`와 `twrnc`를 사용합니다:
-
-```tsx
-import { cva, type VariantProps } from 'cva';
-import { tw } from '../lib/tw';
-
-const buttonVariants = cva({
-  cva: 'items-center justify-center rounded-md',
-  variants: {
-    variant: {
-      primary: 'bg-primary',
-      secondary: 'bg-secondary',
-    },
-    size: {
-      small: 'py-sm px-md',
-      medium: 'py-md px-lg',
-    },
-  },
-  defaultVariants: {
-    variant: 'primary',
-    size: 'medium',
-  },
-});
-
-export const Button: React.FC<ButtonProps> = ({ variant, size, ...props }) => {
-  const buttonStyle = useMemo(() => tw.style(buttonVariants({ variant, size })), [variant, size]);
-
-  return <TouchableOpacity style={buttonStyle} {...props} />;
-};
-```
-
-### 상태 관리 (Zustand)
-
-```typescript
-import { create } from 'zustand';
-
-interface State {
-  user: User | null;
-  isLoading: boolean;
-}
-
-interface Actions {
-  signIn: (provider: AuthProvider) => Promise<void>;
-  signOut: () => Promise<void>;
-}
-
-type AuthStore = State & Actions;
-
-export const useAuthStore = create<AuthStore>((set, get) => ({
-  user: null,
-  isLoading: false,
-
-  signIn: async provider => {
-    set({ isLoading: true });
-    // 인증 로직...
-  },
-
-  signOut: async () => {
-    // 로그아웃 로직...
-  },
-}));
-```
-
-### 1. 의존성 설치
-
-먼저 pnpm을 설치합니다 (아직 설치하지 않은 경우):
-
-```bash
-npm install -g pnpm
-```
-
-루트 디렉토리에서 의존성을 설치합니다:
+### 의존성 설치
 
 ```bash
 pnpm install
 ```
 
-### 2. 패키지 빌드
-
-모든 패키지를 빌드합니다:
+### 앱 실행
 
 ```bash
-pnpm run build
-```
-
-### 3. 개발 모드 실행
-
-#### Mobile 앱 개발:
-
-```bash
-# Metro bundler 시작 (mobile만 실행, .env.dev 사용)
 pnpm dev
-
-# 별도 터미널에서 Android/iOS 실행
-cd apps/mobile
-pnpm android  # 또는 pnpm ios
+cd apps/mobile && pnpm android # 또는 pnpm ios
 ```
 
-#### Storybook 개발:
+### 디자인 시스템/스토리북
 
 ```bash
-# Storybook만 실행
-pnpm dev:storybook
+pnpm storybook:generate // 최초 1회
+pnpm storybook:web
+pnpm storybook:android
 ```
 
-#### 개별 앱 실행:
+## 테스트 실행
 
 ```bash
-# Mobile Metro bundler
-cd apps/mobile && pnpm dev
-
-# Storybook
-cd apps/storybook && pnpm dev
+pnpm test
+pnpm test:mobile
+pnpm test:watch
+pnpm test:coverage
 ```
 
-## 주요 명령어
+---
 
-### 개발
+## AGENTS (AI 어시스턴트)
 
-```bash
-pnpm dev              # Mobile 앱 개발 모드 (Metro bundler)
-pnpm android          # Android 앱 실행 + adb reverse
-pnpm ios              # iOS 앱 실행
-pnpm dev:storybook    # Storybook 개발 모드
-```
+- 기본적으로 Claude를 사용합니다.
+- 컨텍스트/스킬 정의 파일 위치:
+  - 관리 레포 : [AI 템플릿 레포](https://github.com/Mockly-Company/AI_TEMPLATE)
+  - 컨텍스트 : [AGENTS.md](./AGENTS.md) (루트)
+  - 스킬 : [Skill 폴더](./.claude/skills)
+    └─ 종류:
+    - [backend-test-generator](./.claude/skills/backend-test-generator/SKILL.md)
+    - [code-review](./.claude/skills/code-review/SKILL.md)
+    - [commit-message-formatter](./.claude/skills/commit-message-formatter/SKILL.md)
+    - [frontend-test-generator](./.claude/skills/frontend-test-generator/SKILL.md)
+    - [github-issue-generator](./.claude/skills/github-issue-generator/SKILL.md)
+    - [github-task-ticket-generator](./.claude/skills/github-task-ticket-generator/SKILL.md)
+    - [pr-message-generator](./.claude/skills/pr-message-generator/SKILL.md)
+    - [prompt-enhancer](./.claude/skills/prompt-enhancer/SKILL.md)
+    - [skill-creator](./.claude/skills/skill-creator/SKILL.md)
+  - 커맨드 : [명령어 폴더](./.claude/commands/)
+    └─ 종류:
+    - [code-review](./.claude/commands/code-review.md)
+    - [review-backend](./.claude/commands/review-backend.md)
+    - [review-frontend](./.claude/commands/review-frontend.md)
 
-### 빌드
+실제 협업/자동화/AI 활용 시 위 파일을 참고하세요.
 
-```bash
-pnpm build            # TypeScript 타입 체크
-pnpm build:android    # Android 프로덕션 번들 생성
-pnpm build:ios        # iOS 프로덕션 번들 생성
-```
+## 커밋 메시지 규칙
 
-### 코드 품질
+커밋 메시지 규칙은 [commitlint.config.js](./commitlint.config.js) 파일로 설정합니다.
 
-```bash
-pnpm lint             # ESLint 검사
-pnpm lint:fix         # ESLint 자동 수정
-pnpm format           # Prettier 포맷팅
-pnpm format:check     # Prettier 체크 (CI용)
-pnpm type-check       # TypeScript 타입 체크
-```
-
-### 테스트
-
-```bash
-pnpm test             # 전체 테스트 실행
-pnpm test:mobile      # Mobile 앱 테스트만 실행
-pnpm test:watch       # Watch 모드
-pnpm test:coverage    # 커버리지 포함
-pnpm test:verbose     # 상세 로그 포함
-```
-
-### 클린
-
-```bash
-pnpm clean            # node_modules 및 빌드 산출물 삭제
-```
-
-## 새 패키지 추가하기
-
-1. `packages/` 디렉토리에 새 폴더 생성
-2. `package.json` 생성 (name은 `@mockly/[package-name]` 형식)
-3. 필요한 경우 `tsconfig.json` 생성
-4. `src/index.ts` 진입점 생성
-5. 루트에서 `pnpm install` 실행
-
-## 패키지 간 의존성
-
-pnpm workspace를 사용하여 패키지는 다음과 같이 서로를 참조할 수 있습니다:
-
-```json
-{
-  "dependencies": {
-    "@mockly/entities": "workspace:*",
-    "@mockly/design-system": "workspace:*"
-  }
-}
-```
-
-## Git Hooks & 코드 품질
-
-### 커밋 메시지 규칙
-
-**형식**: `[type] subject`
-
-**사용 가능한 타입**:
-
-- `feat`: 새로운 기능
-- `fix`: 버그 수정
-- `docs`: 문서 변경
-- `style`: 코드 포맷팅 (기능 변경 없음)
-- `refactor`: 코드 리팩터링
-- `test`: 테스트 코드
-- `chore`: 빌드 작업, 패키지 매니저 설정
-- `perf`: 성능 개선
-- `ci`: CI 설정 변경
-- `build`: 빌드 시스템 변경
-- `revert`: 커밋 되돌리기
-
-**예시**:
-
-```
-[feat] Google 로그인 기능 추가
-[fix] 토큰 갱신 로직 수정
-[test] Auth Store 테스트 추가
-```
-
-### Husky + lint-staged
-
-프로젝트에 Git Hooks가 설정되어 있어 코드 품질을 자동으로 관리합니다.
-
-#### Pre-commit Hook
-
-커밋 전에 자동 실행:
-
-- **lint-staged**: 변경된 파일에 대해 ESLint 자동 수정 + Prettier 포맷팅
-- **type-check**: 전체 프로젝트 TypeScript 타입 체크
-
-#### Commit-msg Hook
-
-커밋 메시지 검증 (commitlint 적용)
-
-### TypeScript
-
-- **Strict 모드** 활성화
-- 명시적 `any` 금지 (경고만 표시)
-- 사용하지 않는 변수는 `_`로 시작해야 함
-- 공통 설정은 `@mockly/typescript-config` 사용
-
-### ESLint
-
-- TypeScript, React, React Native 규칙 적용
-- Prettier와 통합
-- 커밋 시 자동 수정
-- 화살표 함수 매개변수 괄호: avoid (한 개일 경우)
-- `_` 접두사 사용 시 사용하지 않는 변수 무시
-
-### Prettier
-
-코드 스타일 설정:
-
-```json
-{
-  "semi": true,
-  "trailingComma": "es5",
-  "singleQuote": true,
-  "printWidth": 100,
-  "tabWidth": 2,
-  "useTabs": false,
-  "arrowParens": "avoid",
-  "endOfLine": "lf"
-}
-```
-
-## 테스트 전략
-
-### 테스트 구조
-
-```
-__tests__/
-├── features/
-│   └── auth/
-│       ├── store.test.tsx        # Auth Store 통합 테스트
-│       └── GoogleAuth.test.ts    # GoogleAuthService 단위 테스트
-├── navigation/
-│   └── BottomTabNavigator.test.tsx
-├── ui/
-│   └── screens/
-│       └── MyPageScreen.test.tsx
-└── utils/
-    └── stringUtils.test.ts
-```
-
-### 테스트 원칙
-
-1. **커버리지보다 실용성**: 단순 setter 테스트 지양
-2. **통합 테스트 선호**: 실제 사용 케이스 중심
-3. **에러 케이스 포함**: 네트워크 오류, Storage 실패 등 검증
-4. **Mock 공통화**: 반복되는 Mock 설정은 헬퍼 함수로 추출
-5. **타입 안전**: `jest.fn<ReturnType, Parameters>()` 형식 사용
-
-### 테스트 실행
-
-```bash
-pnpm test              # 전체 테스트
-pnpm test:watch        # Watch 모드
-pnpm test:coverage     # 커버리지 포함
-pnpm test:verbose      # 상세 로그 포함
-```
-
-## 스타일링 (twrnc)
-
-Design System은 `twrnc`를 사용하여 Tailwind CSS 기반의 스타일링을 제공합니다.
-
-### 사용 방법
-
-```tsx
-import { View, Text } from 'react-native';
-import { tw } from '@mockly/design-system';
-
-// twrnc를 통한 Tailwind 스타일 사용
-<View style={tw`bg-primary p-md rounded-lg`}>
-  <Text style={tw`text-xl font-semibold text-white`}>Hello World</Text>
-</View>;
-```
-
-### 사용 가능한 클래스
-
-- **Colors**: `bg-primary`, `text-secondary`, `border-error` 등
-- **Spacing**: `p-xs`, `m-md`, `gap-lg` 등
-- **Font Size**: `text-sm`, `text-lg` 등
-- **Font Weight**: `font-regular`, `font-bold` 등
-- **Border Radius**: `rounded-sm`, `rounded-lg` 등
-
-모든 값은 `packages/design-system/src/theme/index.ts`에서 관리됩니다.
-
-### 스타일링 규칙
-
-1. **테마 토큰 우선**: 값 하드코딩 금지, 테마 토큰 또는 `cva`, `tw` 사용
-2. **스타일 우선순위**: `tw`, `cva` 함수 우선, 필요 시 `StyleSheet.create` 사용 (inline 객체 금지)
-3. **컴포넌트 props**: React Native 기본 컴포넌트에서 확장 (`extends TouchableOpacityProps`)
-
-## 라이선스
-
-MIT
+- `[type] subject` (예: `[feat] Google 로그인 기능 추가`)
+- type: feat, fix, docs, style, refactor, test, chore, perf, ci, build, revert

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -1,374 +1,97 @@
-# Mockly Mobile
+# Mockly Mobile 앱 개발자용 README
 
-React Native 모바일 애플리케이션 - Feature-based 아키텍처
+> 전체 모노레포 구조, 공통 규칙, 디자인 시스템 안내는 [프로젝트 루트 README](../../README.md) 참고!
 
-## 프로젝트 구조
+---
+
+## 📱 모바일 앱 빠른 시작
+
+1. **환경 준비**
+   - Node.js, Android Studio, Xcode 설치
+   - React Native 공식 가이드 참고: https://reactnative.dev/docs/environment-setup
+
+2. **환경 변수 파일 생성**
+   - `apps/mobile/.env.dev` 파일을 반드시 생성
+   - 예시:
+     ```env
+     GOOGLE_WEB_CLIENT_ID=your_google_web_client_id
+     GOOGLE_IOS_CLIENT_ID=your_google_ios_client_id
+     GOOGLE_ANDROID_CLIENT_ID=your_google_android_client_id
+     API_BASE_URL=http://localhost:8080
+     ```
+
+3. **의존성 설치**
+
+   ```bash
+   pnpm install
+   ```
+
+4. **앱 실행**
+
+   ```bash
+   pnpm dev
+   pnpm android   # 또는 pnpm ios
+   ```
+
+5. **테스트 실행**
+   ```bash
+   pnpm test:mobile
+   pnpm test:watch
+   pnpm test:coverage
+   ```
+
+---
+
+## 📂 주요 폴더 구조 (모바일)
 
 ```
 src/
-├── app/                          # 프레젠테이션 레이어
-│   ├── navigation/               # 네비게이션 설정
-│   │   └── BottomTabNavigator.tsx
-│   ├── screens/                  # 화면 컴포넌트 (기능별 그룹화)
-│   │   ├── home/
-│   │   │   └── HomeScreen.tsx
-│   │   ├── chat/
-│   │   │   └── ChatScreen.tsx
-│   │   ├── interview/
-│   │   │   ├── InterviewScreen.tsx
-│   │   │   └── LocalInterviewScreen.tsx
-│   │   └── profile/
-│   │       └── MyPageScreen.tsx
-│   └── components/
-│       ├── common/               # 공통 컴포넌트
-│       └── ui/                   # UI 컴포넌트
-│           └── GoogleLoginButton.tsx
-├── features/                     # 도메인 로직 (기능별 모듈)
-│   └── auth/                     # 인증 기능
-│       ├── AuthContext.tsx       # 인증 Context Provider
-│       ├── hooks.ts              # useAuth 훅
-│       └── types.ts              # 인증 관련 타입
-├── shared/                       # 공유 유틸리티
-│   ├── api/                      # API 클라이언트
-│   ├── hooks/                    # 공통 훅
-│   ├── constants/                # 상수
-│   ├── utils/                    # 유틸 함수
-│   │   └── stringUtils.ts
-│   └── types/                    # 공통 타입
-├── lib/                          # 서드파티 라이브러리 통합
-│   ├── app-auth/                 # OAuth 인증
-│   │   └── pkceAuth.ts           # PKCE 기반 Google OAuth
-│   └── storage/                  # 저장소 관련
-└── styles/                       # 글로벌 스타일
+├── app/
+│   ├── screens/        # 화면 컴포넌트
+│   ├── navigation/     # 내비게이션 설정
+│   └── components/     # 앱 전용 컴포넌트
+├── features/           # 도메인별 기능
+├── shared/             # 공통 상수/유틸
+├── lib/                # 외부 라이브러리 래퍼
+__tests__/              # 모바일 테스트 코드
 ```
 
-## 기술 스택
+---
 
-- **React Native** 0.82.1
-- **TypeScript** 5.9.3
-- **NativeWind** 4.2.1 (Tailwind CSS for React Native)
-- **React Navigation** - 네비게이션
-- **AsyncStorage** - 로컬 저장소
-- **react-native-app-auth** - PKCE OAuth 인증
+## 🛠️ 모바일 개발/디버깅 팁
 
-## 주요 기능
+- **에뮬레이터/실기기 테스트**: Android Studio/Xcode에서 직접 실행 가능
+- **Fast Refresh/Hot Reload**: 코드 변경 즉시 반영
+- **환경 변수 변경 시**: 앱 재시작 필요
+- **로그/디버깅**: React Native Debugger, Flipper 등 활용
+- **트러블슈팅**: Metro 캐시 문제 시 `pnpm start --reset-cache` 사용
 
-### 인증 (Authentication)
+---
 
-- PKCE 기반 Google OAuth 로그인
-- 자동 토큰 갱신
-- AsyncStorage를 통한 로그인 상태 유지
+## 🧪 모바일 테스트 전략
 
-### 네비게이션
+- **테스트 폴더**: `__tests__/features`, `__tests__/ui`, ...
+- **테스트 도구**: Jest, @testing-library/react-native
+- **실제 사용 케이스 중심 통합 테스트 권장**
 
-- Bottom Tab Navigator (5개 탭)
-  - 홈
-  - 동네면접
-  - 면접
-  - 채팅
-  - 마이페이지
+---
 
-## 아키텍처 원칙
+## ✨ 디자인 시스템 컴포넌트 사용법
 
-### Feature-Based Structure
+- 모든 UI 컴포넌트는 `@mockly/design-system` 패키지에서 import
+- 예시:
+  ```tsx
+  import { Button, Card, Text } from '@mockly/design-system';
+  ```
+- 다크모드/variant는 tailwind(twrnc) + cva로 관리
 
-- **app/**: 프레젠테이션 레이어 - UI 컴포넌트, 화면, 네비게이션
-- **features/**: 도메인 로직 - 비즈니스 로직을 기능별로 모듈화
-- **shared/**: 공유 리소스 - 재사용 가능한 유틸리티, 훅, 타입
-- **lib/**: 외부 라이브러리 통합 - 서드파티 라이브러리 래퍼
+---
 
-### 스타일링 규칙
+## 📑 기타 참고
 
-- NativeWind (tw) 사용 권장
-- StyleSheet는 레거시 코드에만 존재
-- 일관된 스타일 패턴 유지
+- 앱 아이콘/스플래시/푸시 등 모바일 특화 설정은 별도 문서 참고
+- 배포(테스트플라이트, 구글 플레이)는 루트 README 또는 별도 배포 문서 참고
 
-## Getting Started
+---
 
-> **Note**: Make sure you have completed the [Set Up Your Environment](https://reactnative.dev/docs/set-up-your-environment) guide before proceeding.
-
-## Step 1: 환경 변수 설정
-
-프로젝트 루트에 `.env.dev` 파일을 생성하고 다음 환경 변수를 설정합니다:
-
-```sh
-NODE_ENV=development
-API_BASE_URL=your_api_url_here
-GOOGLE_WEB_CLIENT_ID=your_google_client_id_here
-```
-
-## Step 2: 의존성 설치
-
-```sh
-# pnpm 사용 (권장)
-pnpm install
-
-# iOS의 경우 CocoaPods 설치
-cd ios && bundle install && bundle exec pod install && cd ..
-```
-
-## Step 3: Metro 서버 시작
-
-먼저 Metro 서버를 실행합니다:
-
-```sh
-# pnpm 사용
-pnpm dev
-
-# 또는 npm/yarn
-npm start
-yarn start
-```
-
-## Step 4: 앱 빌드 및 실행
-
-With Metro running, open a new terminal window/pane from the root of your React Native project, and use one of the following commands to build and run your Android or iOS app:
-
-### Android
-
-```sh
-# Using npm
-npm run android
-
-# OR using Yarn
-yarn android
-```
-
-### iOS
-
-For iOS, remember to install CocoaPods dependencies (this only needs to be run on first clone or after updating native deps).
-
-The first time you create a new project, run the Ruby bundler to install CocoaPods itself:
-
-```sh
-bundle install
-```
-
-Then, and every time you update your native dependencies, run:
-
-```sh
-bundle exec pod install
-```
-
-For more information, please visit [CocoaPods Getting Started guide](https://guides.cocoapods.org/using/getting-started.html).
-
-```sh
-# Using npm
-npm run ios
-
-# OR using Yarn
-yarn ios
-```
-
-## Step 4: 앱 빌드 및 실행
-
-Metro가 실행 중인 상태에서 새 터미널을 열고 다음 명령어로 앱을 실행합니다:
-
-### Android
-
-```sh
-# pnpm 사용
-pnpm android
-
-# 또는 npm/yarn
-npm run android
-yarn android
-```
-
-### iOS
-
-```sh
-# pnpm 사용
-pnpm ios
-
-# 또는 npm/yarn
-npm run ios
-yarn ios
-```
-
-## 개발 도구
-
-### 테스트 실행
-
-```sh
-# 모든 테스트 실행
-pnpm test
-
-# 특정 테스트 파일 실행
-pnpm test --testPathPattern=MyPageScreen
-```
-
-### 타입 체크
-
-```sh
-pnpm type-check
-```
-
-### 린트
-
-```sh
-# ESLint 실행
-pnpm lint
-
-# 자동 수정
-pnpm lint:fix
-
-# Prettier 포맷팅
-pnpm format
-```
-
-## 코드 작성 가이드
-
-### 새로운 기능 추가하기
-
-1. **도메인 로직**: `src/features/` 에 새 기능 폴더 생성
-2. **화면 컴포넌트**: `src/app/screens/` 에 기능별 폴더 생성
-3. **공통 컴포넌트**: `src/app/components/` 에 추가
-4. **유틸리티**: `src/shared/utils/` 에 추가
-
-### Import 경로 규칙
-
-```typescript
-// 도메인 로직 import
-import { useAuth } from '@/features/auth/hooks';
-
-// 화면 컴포넌트 import
-import { HomeScreen } from '@/app/screens/home/HomeScreen';
-
-// 공유 유틸리티 import
-import { capitalize } from '@/shared/utils/stringUtils';
-
-// 서드파티 통합 import
-import { authorizeWithPKCE } from '@/lib/app-auth/pkceAuth';
-```
-
-### 스타일링 가이드
-
-```typescript
-import { View, Text } from 'react-native';
-import { tw } from '@mockly/design-system';
-
-const containerStyle = tw`flex-1 justify-center items-center bg-white`;
-const titleStyle = tw`text-2xl font-bold text-gray-900`;
-
-export const MyScreen = () => {
-  return (
-    <View style={containerStyle}>
-      <Text style={titleStyle}>Hello World</Text>
-    </View>
-  );
-};
-```
-
-## Google OAuth 설정
-
-### Android Client ID 생성
-
-1. [Google Cloud Console](https://console.cloud.google.com/) 접속
-2. OAuth 2.0 클라이언트 ID 생성 (Android 타입)
-3. 패키지 이름: `com.mobile` (또는 `app.json`의 package 이름)
-4. SHA-1 인증서 지문 등록
-5. 생성된 Client ID를 `.env.dev`의 `GOOGLE_WEB_CLIENT_ID`에 설정
-
-### Redirect URI
-
-백엔드 엔드포인트를 사용합니다:
-
-```
-${API_BASE_URL}/login/oauth2/code/google
-```
-
-자세한 내용은 `GOOGLE_LOGIN_SETUP.md` 참조
-
-## 프로젝트 구조 설명
-
-### app/ - 프레젠테이션 레이어
-
-사용자에게 보여지는 모든 UI 관련 코드
-
-- 화면 컴포넌트
-- 네비게이션
-- UI 컴포넌트
-
-### features/ - 도메인 로직
-
-비즈니스 로직을 기능별로 모듈화
-
-- Context Providers
-- Custom Hooks
-- 도메인 타입
-- 각 기능은 독립적으로 동작 가능
-
-### shared/ - 공유 리소스
-
-여러 기능에서 공통으로 사용하는 코드
-
-- 유틸리티 함수
-- 공통 훅
-- 공통 타입
-- 상수
-
-### lib/ - 서드파티 통합
-
-외부 라이브러리를 래핑하여 사용
-
-- OAuth 인증
-- 저장소
-- 분석 도구 등
-
-## 문제 해결
-
-### Metro Bundler 캐시 삭제
-
-```sh
-pnpm start --reset-cache
-```
-
-### iOS Pod 재설치
-
-```sh
-cd ios && rm -rf Pods Podfile.lock && bundle exec pod install && cd ..
-```
-
-### Android 빌드 캐시 삭제
-
-```sh
-cd android && ./gradlew clean && cd ..
-```
-
-## 관련 문서
-
-- [Google Login Setup](./GOOGLE_LOGIN_SETUP.md) - Google OAuth 설정 가이드
-- [PKCE Auth Documentation](./docs/PKCE_AUTH.md) - PKCE 인증 플로우 설명
-
-## 앱 수정하기
-
-`src/app/screens/` 또는 원하는 파일을 수정하면 Fast Refresh가 자동으로 변경사항을 반영합니다.
-
-강제 새로고침:
-
-- **Android**: <kbd>R</kbd> 키를 두 번 누르거나 <kbd>Ctrl</kbd> + <kbd>M</kbd>에서 Reload 선택
-- **iOS**: <kbd>Cmd ⌘</kbd> + <kbd>R</kbd>
-
-## 배포
-
-### Android APK 빌드
-
-```sh
-cd android && ./gradlew assembleRelease
-```
-
-### iOS Archive
-
-Xcode에서 Product > Archive 선택
-
-## 기여하기
-
-1. 브랜치 생성: `git checkout -b feat/new-feature`
-2. 변경사항 커밋: 커밋 컨벤션 준수 (`[feat]`, `[fix]` 등)
-3. Push: `git push origin feat/new-feature`
-4. Pull Request 생성
-
-## 라이선스
-
-이 프로젝트는 Mockly Company의 소유입니다.
+> 공통 규칙, 커밋 메시지, AGENTS 안내 등은 [루트 README](../../README.md)에서 확인하세요!

--- a/apps/mobile/src/app/navigation/RootNavigator.tsx
+++ b/apps/mobile/src/app/navigation/RootNavigator.tsx
@@ -1,10 +1,11 @@
+import { useAuth } from '@features/auth/hooks';
 import { BottomTabNavigator } from './BottomTabNavigator';
 
 // import { useAuth } from '@features/auth/hooks';
 import { LandingNavigator } from './LandingNavigator';
 
 export const RootNavigator = () => {
-  // const { isAuthenticated } = useAuth();
+  const { isAuthenticated } = useAuth();
   // 인증 상태에 따른 화면 분기
-  return true ? <BottomTabNavigator /> : <LandingNavigator />;
+  return isAuthenticated ? <BottomTabNavigator /> : <LandingNavigator />;
 };

--- a/apps/storybook/README.md
+++ b/apps/storybook/README.md
@@ -1,0 +1,81 @@
+# Mockly Storybook (디자인 시스템/컴포넌트 문서화)
+
+## 🚀 빠른 시작
+
+1. **의존성 설치**
+   ```bash
+   pnpm install
+   ```
+2. **스토리북 정적 파일 생성 (최초 1회 필수)**
+   ```bash
+   pnpm storybook-generate
+   # storybook-static/ 폴더가 생성되어야 웹/배포 가능
+   ```
+3. **스토리북 실행**
+   ```bash
+   pnpm storybook-generate
+   pnpm storybook:web      # 웹 프리뷰
+   pnpm storybook:android # 안드로이드 에뮬레이터
+   ```
+4. **Chromatic 배포**
+   ```bash
+   pnpm chromatic
+   # .env 또는 .env.dev에 CHROMATIC_PROJECT_TOKEN 등 환경변수 필요
+   ```
+
+---
+
+## 📂 주요 폴더 구조
+
+```
+apps/storybook/
+├── src/                # 공통 스토리/컴포넌트
+│   ├── AnimationOverview.stories.tsx
+│   ├── ComponentsOverview.stories.tsx
+│   ├── FoundationOverview.stories.tsx
+│   ├── LayoutOverview.stories.tsx
+│   └── screens/
+├── storyForWeb/        # 웹 전용 스토리
+│   └── Welcome.stories.tsx
+├── storyForMobile/     # 모바일 전용 스토리
+│   └── WelcomeMoible.stories.tsx
+├── storybook-static/   # 정적 빌드 결과물 (자동 생성)
+├── public/             # 폰트/이미지 등
+├── __tests__/          # 스토리북 테스트
+```
+
+---
+
+## ✨ 주요 기능
+
+- 디자인 시스템 컴포넌트 실시간 프리뷰/문서화
+- 다크/라이트 모드 토글 지원
+- 테마/컬러 토큰 확인 가능
+- Storybook에서 바로 컴포넌트 props/variant 테스트
+- 웹/모바일 스토리 분리 관리
+- **컴포넌트 개별 스토리**는 `@mockly/design-system` 패키지에서 선언
+- **페이지 단위/전체 개요 스토리**는 Storybook 프로젝트(`apps/storybook`)에서 관리
+
+---
+
+## 🧪 테스트
+
+- 스토리북 자체 테스트: `__tests__/storybook.test.ts`
+- 컴포넌트 단위/통합 테스트는 각 패키지(`@mockly/design-system`)에서 관리
+
+---
+
+## 📑 기타 참고
+
+- 디자인 시스템 전체 구조/가이드: [루트 README](../../README.md) 및 [@mockly/design-system]
+- 스토리북 배포/공유: Chromatic 등 외부 서비스 연동 가능
+- Chromatic 배포 환경변수 예시:
+  ```env
+  // .env
+  CHROMATIC_PROJECT_TOKEN=your_chromatic_token
+  CHROMATIC_USER_ID=your_chromatic_user_id
+  ```
+
+---
+
+> 공통 규칙, 커밋 메시지, AGENTS 안내 등은 [루트 README](../../README.md)에서 확인하세요!

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,md}\"",
     "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,json,md}\"",
     "prepare": "husky",
-    "postinstall": "git config commit.template .gitmessage"
+    "postinstall": "git config commit.template .gitmessage",
+    "storybook:generate": "turbo run storybook-generate --filter=@mockly/storybook"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx}": [

--- a/packages/design-system/README.md
+++ b/packages/design-system/README.md
@@ -1,0 +1,125 @@
+# Mockly 디자인 시스템
+
+모던 React Native UI 컴포넌트/테마 패키지
+
+---
+
+## ✨ 주요 특징
+
+- 재사용 가능한 UI 컴포넌트 (Button, Card, Text, Badge, Avatar 등)
+- 다크/라이트 모드 지원, 테마 토큰 기반 스타일링
+- tailwind(twrnc) + cva로 variant/size/상태 관리
+- Storybook 연동, 실시간 프리뷰/문서화
+- 타입 안전성, 접근성(Accessibility) 고려
+
+---
+
+## 📂 폴더 구조
+
+```
+src/
+├── components/      # 주요 UI 컴포넌트 (Button, Card, Text, ...)
+│   ├── Button/
+│   ├── Card/
+│   ├── Text/
+│   └── ...
+├── layout/          # 레이아웃/그리드 컴포넌트
+├── animations/      # 애니메이션 컴포넌트
+├── theme/           # 테마/컬러 토큰
+├── stories/         # 디자인 토큰/가이드 스토리
+│   ├── Colors.stories.tsx
+│   ├── Typography.stories.tsx
+│   └── ...
+├── lib/             # 내부 유틸리티/헬퍼
+└── index.ts         # 패키지 엔트리
+```
+
+### components 종류
+
+- Avatar
+- Badge
+- Button
+- Card
+- Carousel
+- Icon
+- Indicator
+- Input
+- Text
+
+### layout 종류
+
+- Grid
+- Spacer
+- Stack
+
+### animations 종류
+
+- FadeIn, FadeInText, FadeOut, FadeOutText
+- ScaleIn, ScaleOut
+- SlideIn, SlideOut
+
+---
+
+## 🛠️ 사용법
+
+```tsx
+import { Button, Card, Text } from '@mockly/design-system';
+
+<Button variant="primary" size="large">확인</Button>
+<Card variant="surface">...</Card>
+<Text variant="heading">타이틀</Text>
+```
+
+- tailwind(twrnc) + cva로 스타일/variant 관리
+- 테마 토큰/다크모드 자동 적용
+
+---
+
+## 🎨 테마/토큰 (상세)
+
+- **컬러 팔레트**: orange, blue, pink, green, yellow, red, gray, neutral 등 50~900 scale로 세분화
+- **라이트/다크 컬러 토큰**: `lightColors`, `darkColors`로 배경/텍스트/버튼/경고 등 역할별 색상 분리
+- **spacing**: xs~2xl까지 여백 단위 제공 (`theme.spacing`)
+- **typography**: fontSize(xs~3xl), fontWeight(regular~bold) 등 텍스트 스타일 토큰 (`theme.typography`)
+- **borderRadius**: sm~full까지 둥근 모서리 토큰 (`theme.borderRadius`)
+- 모든 토큰은 `src/theme/index.ts`에서 관리, theme 객체로 통합
+- **Storybook에서 모든 테마/토큰을 실시간 프리뷰/문서화로 자세히 확인할 수 있습니다.**
+
+### 실제 사용 예시
+
+```tsx
+import { theme } from '@mockly/design-system';
+
+const styles = {
+  backgroundColor: theme.colors.background,
+  color: theme.colors.text,
+  borderRadius: theme.borderRadius.md,
+  padding: theme.spacing.lg,
+  fontSize: theme.typography.fontSize.lg,
+};
+```
+
+### 커스텀 테마 확장 방법
+
+- `src/theme/index.ts`에서 palette/토큰을 추가하거나, colors/spacing/typography를 오버라이드
+- 컴포넌트에서 theme 객체를 import해 일관된 스타일 적용
+
+---
+
+## 🧪 테스트/스토리북
+
+- 컴포넌트 단위/통합 테스트: `__tests__/` 폴더에서 관리
+- Storybook에서 실시간 프리뷰/문서화 지원
+- 개별 컴포넌트 스토리는 이 패키지에서 선언, 전체/페이지 단위 스토리는 Storybook 프로젝트에서 관리
+
+---
+
+## 📑 기타 참고
+
+- 디자인 시스템 전체 구조/가이드: [프로젝트 루트 README](../../../README.md)
+- 확장/기여: 새로운 컴포넌트는 `src/components/`에 추가, 테마는 `src/theme/`에서 확장
+- 접근성/테스트/다크모드 등은 기존 컴포넌트 코드 참고
+
+---
+
+> 공통 규칙, 커밋 메시지, AGENTS 안내 등은 [루트 README](../../../README.md)에서 확인하세요!

--- a/turbo.json
+++ b/turbo.json
@@ -59,6 +59,10 @@
     },
     "clean": {
       "cache": false
+    },
+    "storybook-generate": {
+      "outputs": ["storybook-static/**"],
+      "cache": false
     }
   }
 }


### PR DESCRIPTION
## 설명
프로젝트의 README 문서를 사용자 친화적으로 전면 개편하였습니다. 루트 README는 전체 모노레포 구조와 빠른 시작 가이드 중심으로 간소화하고, 모바일 앱과 스토리북 README는 각 패키지별 개발자용 가이드로 분리하여 문서 구조를 개선했습니다.

## 변경 내용
- 루트 README를 모노레포 개요 및 빠른 시작 가이드 중심으로 재구성
- 패키지/앱별 역할 요약 테이블 추가
- 디자인 시스템 스크린샷 및 Chromatic 링크 포함
- 모바일 앱 README를 개발자용 실용 가이드로 간소화
- 스토리북 README를 새로 작성하여 디자인 시스템 문서화 가이드 제공
- AGENTS 및 스킬/커맨드 안내 추가
- 환경 설정, 테스트, 개발 팁 등 실용적인 내용 강화
- RootNavigator에서 인증 상태 분기 로직 활성화 (주석 제거)
- 불필요한 상세 설명 제거 및 가독성 향상

## 추가 내용
- apps/storybook/README.md 신규 작성
- packages/design-system/README.md 신규 작성