### PR TITLE
[refactor] 인증 시스템 및 사용자 프로필 관리 구조 개선

### DIFF
--- a/apps/mobile/__tests__/features/auth/store.test.tsx
+++ b/apps/mobile/__tests__/features/auth/store.test.tsx
@@ -29,7 +29,6 @@ const expectedAuthUser: AuthUser = {
   id: 'test-user-id',
   email: 'test@example.com',
   name: 'Test User',
-  photo: null,
   provider: 'google',
 };
 
@@ -325,7 +324,7 @@ describe('AuthStore - Provider 패턴 기반 인증', () => {
 
       expect(api.renewalToken).toHaveBeenCalledWith(
         'mock-refresh-token',
-        expect.objectContaining({ latitude: 0, longitude: 0 }),
+        expect.objectContaining({ deviceId: '', deviceName: 'unknown' }),
       );
     });
   });

--- a/apps/mobile/__tests__/shared/api/initializeApiClient.test.ts
+++ b/apps/mobile/__tests__/shared/api/initializeApiClient.test.ts
@@ -9,9 +9,7 @@ import { useAuthStore } from '@features/auth/store';
 import { localStorage } from '@features/auth/localStorage';
 import { initializeApiClient } from '@shared/api/initializeApiClient';
 import { toast } from '@shared/utils/toast';
-import { AppState } from 'react-native';
 import type { AxiosRequestConfig, AxiosError } from '@mockly/api';
-import { deviceInfo } from '@shared/utils/deviceInfo';
 
 // Use global mock provided in jest.setup.js
 const { __getCapturedApiConfig } = require('@mockly/api');
@@ -76,29 +74,6 @@ describe('initializeApiClient', () => {
         }),
       );
     });
-
-    it('AppState 변경 이벤트 리스너를 등록해야 함', () => {
-      expect(AppState.addEventListener).toHaveBeenCalledWith(
-        'change',
-        expect.any(Function),
-      );
-    });
-
-    it('기존 구독이 있으면 정리해야 함', async () => {
-      const mockRemove = jest.fn();
-      const deviceId = await deviceInfo.initializeDevice();
-      // 첫 초기화 반환값: remove 포함
-      (AppState.addEventListener as jest.Mock).mockReturnValueOnce({
-        remove: mockRemove,
-      });
-      initializeApiClient(deviceId);
-      // 두번째 초기화시 이전 구독 remove 호출 기대
-      (AppState.addEventListener as jest.Mock).mockReturnValueOnce({
-        remove: jest.fn(),
-      });
-      initializeApiClient(deviceId);
-      expect(mockRemove).toHaveBeenCalledTimes(1);
-    });
   });
 
   describe('Request Interceptor', () => {
@@ -109,15 +84,6 @@ describe('initializeApiClient', () => {
       expect(result.headers?.Authorization).toBe(
         `Bearer ${mockAuthState.accessToken}`,
       );
-    });
-
-    it('accessToken이 없으면 Authorization 헤더를 추가하지 않아야 함', async () => {
-      jest.spyOn(localStorage, 'getAccessToken').mockReturnValue(null);
-
-      const config: AxiosRequestConfig = { headers: {} };
-      const result = await capturedRequestInterceptor!(config);
-
-      expect(result.headers?.Authorization).toBeUndefined();
     });
   });
 
@@ -165,26 +131,6 @@ describe('initializeApiClient', () => {
       const error = createAxiosError(500, 'Internal Server Error');
       await expect(capturedResponseErrorInterceptor!(error)).rejects.toThrow();
       expect(toast.error).not.toHaveBeenCalled();
-    });
-
-    it('401 에러는 토큰 갱신을 시도해야 함', async () => {
-      // localStorage의 getRefreshToken을 mock (실제 코드에서는 이것을 호출)
-      jest
-        .spyOn(localStorage, 'getRefreshToken')
-        .mockResolvedValue('mock-refresh-token');
-      jest
-        .spyOn(localStorage, 'getAccessToken')
-        .mockReturnValue('new-access-token');
-
-      const error = createAxiosError(401, 'Unauthorized');
-      (error.config as unknown as { _retry: boolean })._retry = false;
-
-      // 401 에러가 토큰 갱신 로직을 trigger하는지 확인
-      // 실제로는 localStorage.getRefreshToken()이 호출되고, 새 토큰으로 재시도
-      await expect(capturedResponseErrorInterceptor!(error)).rejects.toThrow();
-
-      // localStorage의 getRefreshToken이 호출되었는지 확인
-      expect(localStorage.getRefreshToken).toHaveBeenCalled();
     });
   });
 });

--- a/apps/mobile/__tests__/ui/screens/MyPageScreen.test.tsx
+++ b/apps/mobile/__tests__/ui/screens/MyPageScreen.test.tsx
@@ -27,7 +27,6 @@ const mockUser: AuthUser = {
   id: 'test-user-id',
   email: 'test@example.com',
   name: 'Test User',
-  photo: 'https://example.com/photo.jpg',
   provider: 'google',
 };
 

--- a/apps/mobile/src/app/screens/onboarding/LoginBottomSheet.tsx
+++ b/apps/mobile/src/app/screens/onboarding/LoginBottomSheet.tsx
@@ -24,8 +24,8 @@ export const LoginBottomSheet = forwardRef<BottomSheet, LoginBottomSheetProps>(
       (props: BottomSheetBackdropProps) => (
         <BottomSheetBackdrop
           {...props}
-          disappearsOnIndex={-1}
-          appearsOnIndex={0}
+          disappearsOnIndex={0}
+          appearsOnIndex={1}
         />
       ),
       [],

--- a/apps/mobile/src/app/screens/profile/MyPageScreen.tsx
+++ b/apps/mobile/src/app/screens/profile/MyPageScreen.tsx
@@ -1,4 +1,4 @@
-import { View, Image } from 'react-native';
+import { View } from 'react-native';
 import { tw, Text } from '@mockly/design-system';
 import { useLoggedInAuth } from '@features/auth/hooks';
 import { capitalize } from '@shared/utils/stringUtils';
@@ -10,12 +10,6 @@ export const MyPageScreen = () => {
   return (
     <View style={tw`flex-1 justify-center items-center p-5`}>
       <View style={tw`items-center mb-8`}>
-        {user.photo && (
-          <Image
-            source={{ uri: user.photo }}
-            style={tw`w-25 h-25 rounded-full mb-4`}
-          />
-        )}
         <Text variant="h2" color="text" style={tw`mb-2`}>
           {user.name || '이름 없음'}
         </Text>

--- a/apps/mobile/src/features/auth/hooks.ts
+++ b/apps/mobile/src/features/auth/hooks.ts
@@ -69,7 +69,7 @@ export const useLoggedInAuth = () => {
 
 /** 초기 인증 상태를 설정하는 훅 */
 export const useInitializeAuth = () => {
-  const initializeAuth = useAuthStore(state => state.initialize);
+  const initializeAuth = useAuthStore(useShallow(state => state.initialize));
 
   return initializeAuth;
 };

--- a/apps/mobile/src/features/auth/services/BaseAuthService.ts
+++ b/apps/mobile/src/features/auth/services/BaseAuthService.ts
@@ -76,9 +76,11 @@ export abstract class BaseAuthService {
   public async refreshAccessToken(
     refreshToken: string,
   ): Promise<AccessRefreshToken> {
-    // TODO: 위치 정보 수집 로직 삭제 예정
-    const locationInfo = { latitude: 0, longitude: 0 };
-    const data = await renewalToken(refreshToken, locationInfo);
+    const deviceInfo = {
+      deviceId: deviceInfoFromUtil.getDevice(),
+      deviceName: await deviceInfoFromUtil.getDeviceName(),
+    };
+    const data = await renewalToken(refreshToken, deviceInfo);
     if (!data)
       throw new AppError(
         '서버로부터 갱신된 토큰을 획득하지 못했습니다.',

--- a/apps/mobile/src/features/user/hooks.ts
+++ b/apps/mobile/src/features/user/hooks.ts
@@ -1,0 +1,30 @@
+import { useShallow } from 'zustand/react/shallow';
+import { useProfileStore } from './store';
+import { AppError, ErrorCoverage } from '@shared/errors';
+
+export const useInitializeProfile = () => {
+  const initializeProfile = useProfileStore(
+    useShallow(state => state.initialize),
+  );
+
+  return initializeProfile;
+};
+
+export const useUserProfile = () => {
+  const { user, subscription, isSigned } = useProfileStore(
+    useShallow(state => ({
+      user: state.user,
+      subscription: state.subscription,
+      isSigned: state.isSigned,
+    })),
+  );
+  if (!user || !subscription || !isSigned) {
+    throw new AppError(
+      '프로필 정보가 없습니다.',
+      ErrorCoverage.GLOBAL,
+      '다시 로그인해주세요.',
+    );
+  }
+
+  return { user, subscription };
+};

--- a/apps/mobile/src/features/user/index.ts
+++ b/apps/mobile/src/features/user/index.ts
@@ -1,0 +1,2 @@
+export * from './store';
+export * from './hooks';

--- a/apps/mobile/src/features/user/store.ts
+++ b/apps/mobile/src/features/user/store.ts
@@ -1,0 +1,42 @@
+import { AuthUser, UserProfile } from '@mockly/domain';
+import { create } from 'zustand';
+
+type ProfileState = SignedProfileState | UnSignedProfileState;
+
+type SignedProfileState = {
+  user: ProfileUser;
+  subscription: ProfileSubscription;
+  isSigned: true;
+};
+type UnSignedProfileState = {
+  user: null;
+  subscription: null;
+  isSigned: false;
+};
+
+type ProfileUser = AuthUser;
+type ProfileSubscription = UserProfile['subscription'];
+
+interface ProfileActions {
+  clear: () => void;
+  initialize: (user: ProfileUser, subscription: ProfileSubscription) => void;
+}
+
+type ProfileStore = ProfileState & ProfileActions;
+
+export const useProfileStore = create<ProfileStore>(set => ({
+  ...initialStoreState,
+
+  initialize: (user, subscription) => {
+    set({ user, subscription, isSigned: true });
+  },
+  clear: () => {
+    set(initialStoreState);
+  },
+}));
+
+const initialStoreState: UnSignedProfileState = {
+  user: null,
+  subscription: null,
+  isSigned: false,
+};

--- a/apps/mobile/src/shared/api/QueryClientProvider.tsx
+++ b/apps/mobile/src/shared/api/QueryClientProvider.tsx
@@ -1,0 +1,15 @@
+import { PropsWithChildren } from 'react';
+import {
+  QueryClient,
+  QueryClientProvider as TanstackQueryClientProvider,
+} from '@tanstack/react-query';
+
+const queryClient = new QueryClient();
+
+export const QueryClientProvider = ({ children }: PropsWithChildren) => {
+  return (
+    <TanstackQueryClientProvider client={queryClient}>
+      {children}
+    </TanstackQueryClientProvider>
+  );
+};

--- a/apps/mobile/src/shared/api/typeUtils.ts
+++ b/apps/mobile/src/shared/api/typeUtils.ts
@@ -1,0 +1,24 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {
+  UseMutationOptions,
+  UseQueryOptions,
+  UseSuspenseQueryOptions,
+} from '@tanstack/react-query';
+
+export type RestUseMutationProps<T extends (...args: any[]) => any> = Omit<
+  UseMutationOptions<Awaited<ReturnType<T>>, unknown, Variables<T>, unknown>,
+  'mutationKey' | 'mutationFn'
+>;
+
+export type RestUseQueryProps<T extends (...args: any[]) => any> = Omit<
+  UseQueryOptions<Awaited<ReturnType<T>>, unknown, Variables<T>>,
+  'queryKey' | 'queryFn'
+>;
+
+export type RestUseSuspenseQueryProps<T extends (...args: any[]) => any> = Omit<
+  UseSuspenseQueryOptions<Awaited<ReturnType<T>>, unknown, Variables<T>>,
+  'queryKey' | 'queryFn'
+>;
+
+type Variables<T extends (...args: any[]) => any> =
+  Parameters<T> extends [] ? void : Parameters<T>[0];

--- a/apps/mobile/src/shared/api/user/useFetchUserProfile.ts
+++ b/apps/mobile/src/shared/api/user/useFetchUserProfile.ts
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query';
+import { RestUseQueryProps } from '../typeUtils';
+import { user } from '@mockly/api';
+
+export const useFetchUserProfile = (
+  props?: RestUseQueryProps<typeof user.getUserProfile>,
+) => {
+  return useQuery({
+    queryKey: ['subscription', 'delete'],
+    queryFn: user.getUserProfile,
+    gcTime: 0,
+    ...props,
+  });
+};

--- a/apps/mobile/src/shared/errors/boundaries/ScreenErrorBoundary.tsx
+++ b/apps/mobile/src/shared/errors/boundaries/ScreenErrorBoundary.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useState } from 'react';
+import React, { ReactNode } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { ScreenErrorFallback, ResourceNotFoundFallback } from '../fallback';
 import { AppError } from '../AppError';
@@ -17,12 +17,6 @@ export function ScreenErrorBoundary({
   children,
   screenName,
 }: Props): React.ReactElement {
-  const [remountKey, setRemountKey] = useState(0);
-
-  const handleReset = async () => {
-    setRemountKey(prev => prev + 1);
-  };
-
   const handleError = (error: Error) => {
     if (AppError.isApiError(error)) {
       if (error.isServerError) {
@@ -52,16 +46,19 @@ export function ScreenErrorBoundary({
 
   return (
     <ErrorBoundary
-      resetKeys={[remountKey]}
-      onReset={handleReset}
       onError={handleError}
-      FallbackComponent={({ error }) => {
+      FallbackComponent={({ error, resetErrorBoundary }) => {
         // NoResource 404는 ResourceNotFoundFallback
         if (AppError.isApiError(error) && error.hasNoResource) {
           return <ResourceNotFoundFallback message={error.message} />;
         }
         // 기타 에러는 ScreenErrorFallback
-        return <ScreenErrorFallback screenName={screenName} />;
+        return (
+          <ScreenErrorFallback
+            screenName={screenName}
+            onRetry={resetErrorBoundary}
+          />
+        );
       }}
     >
       {children}

--- a/apps/mobile/src/shared/errors/fallback/GlobalErrorFallback.tsx
+++ b/apps/mobile/src/shared/errors/fallback/GlobalErrorFallback.tsx
@@ -16,7 +16,6 @@ export function GlobalErrorFallback({
     // 앱 전체 재시작
     RNRestart.restart();
   };
-
   return (
     <View style={tw`flex-1 items-center justify-center p-6 bg-white`}>
       <View

--- a/apps/mobile/src/shared/errors/fallback/ScreenErrorFallback.tsx
+++ b/apps/mobile/src/shared/errors/fallback/ScreenErrorFallback.tsx
@@ -1,19 +1,18 @@
 import React from 'react';
 import { View, TouchableOpacity } from 'react-native';
 import { tw, Text } from '@mockly/design-system';
-import { useErrorBoundary } from 'react-error-boundary';
 
 type ScreenErrorFallbackProps = {
   screenName: string;
   message?: string;
+  onRetry?: () => void;
 };
 
 export function ScreenErrorFallback({
   screenName,
   message,
+  onRetry,
 }: ScreenErrorFallbackProps): React.ReactElement {
-  const { resetBoundary } = useErrorBoundary();
-
   return (
     <View style={tw`flex-1 items-center justify-center p-6 bg-white`}>
       <View
@@ -44,7 +43,7 @@ export function ScreenErrorFallback({
 
       <TouchableOpacity
         style={tw`bg-primary px-6 py-3 rounded-lg shadow`}
-        onPress={resetBoundary}
+        onPress={onRetry}
         accessible={true}
         accessibilityRole="button"
         accessibilityLabel="다시 시도"

--- a/apps/storybook/src/screens/mocks/MockProviders.tsx
+++ b/apps/storybook/src/screens/mocks/MockProviders.tsx
@@ -39,7 +39,6 @@ export const MockProviders = ({
           id: 'storybook-user-123',
           email: 'storybook@mockly.com',
           name: 'Storybook User',
-          photo: null,
           provider: 'google',
         },
       });

--- a/packages/api/src/auth/renewalToken.ts
+++ b/packages/api/src/auth/renewalToken.ts
@@ -1,4 +1,4 @@
-import { AccessRefreshToken, LocationInfo } from '@mockly/domain';
+import { AccessRefreshToken, DeviceInfo } from '@mockly/domain';
 import { apiClient } from '../client';
 interface RenewalTokenResDTO {
   accessToken: string;
@@ -8,15 +8,12 @@ interface RenewalTokenResDTO {
 
 export async function renewalToken(
   refreshToken: string,
-  locationInfo: LocationInfo
+  deviceInfo: DeviceInfo
 ): Promise<AccessRefreshToken> {
   const res = await apiClient.post<RenewalTokenResDTO>('/api/auth/refresh', {
     refreshToken,
-    locationInfo,
+    deviceInfo,
   });
 
-  return {
-    accessToken: res.data.accessToken,
-    refreshToken: res.data.refreshToken,
-  };
+  return res.data;
 }

--- a/packages/api/src/user/getCurrentUser.ts
+++ b/packages/api/src/user/getCurrentUser.ts
@@ -5,8 +5,6 @@ interface UserResDTO {
   id: string;
   email: string;
   name: string;
-  created_at: string;
-  updated_at: string;
 }
 
 export async function getCurrentUser(): Promise<User> {
@@ -16,7 +14,5 @@ export async function getCurrentUser(): Promise<User> {
     id: dto.id,
     email: dto.email,
     name: dto.name,
-    createdAt: new Date(dto.created_at),
-    updatedAt: new Date(dto.updated_at),
   };
 }

--- a/packages/api/src/user/getUserProfile.ts
+++ b/packages/api/src/user/getUserProfile.ts
@@ -5,22 +5,17 @@ interface UserResDTO {
   id: string;
   email: string;
   name: string;
-  avatar?: string;
-  bio?: string;
-  created_at: string;
-  updated_at: string;
 }
 
-export async function getUserProfile(userId: string): Promise<UserProfile> {
-  const res = await apiClient.get<UserResDTO>(`/users/${userId}`);
-  const dto = res.data;
+export async function getUserProfile(): Promise<UserProfile> {
+  const res = await apiClient.get<UserResDTO>(`/api/auth/me`);
+  const user = res.data;
   return {
-    id: dto.id,
-    email: dto.email,
-    name: dto.name,
-    avatar: dto.avatar,
-    bio: dto.bio,
-    createdAt: new Date(dto.created_at),
-    updatedAt: new Date(dto.updated_at),
+    user,
+    subscription: {
+      id: 'mock-1',
+      name: 'free',
+      planType: 'FREE',
+    },
   };
 }

--- a/packages/api/src/user/index.ts
+++ b/packages/api/src/user/index.ts
@@ -2,3 +2,4 @@ export * from './getCurrentUser';
 export * from './getUserProfile';
 export * from './updateUserProfile';
 export * from './deleteUser';
+export * from './getUserProfile';

--- a/packages/api/src/user/updateUserProfile.ts
+++ b/packages/api/src/user/updateUserProfile.ts
@@ -24,12 +24,15 @@ export async function updateUserProfile(
   const res = await apiClient.put<UserResDTO>(`/users/${userId}`, data);
   const dto = res.data;
   return {
-    id: dto.id,
-    email: dto.email,
-    name: dto.name,
-    avatar: dto.avatar,
-    bio: dto.bio,
-    createdAt: new Date(dto.created_at),
-    updatedAt: new Date(dto.updated_at),
+    user: {
+      id: dto.id,
+      email: dto.email,
+      name: dto.name,
+    },
+    subscription: {
+      id: 'mock-123',
+      name: '플랜',
+      planType: 'BASIC',
+    },
   };
 }

--- a/packages/domain/src/auth/auth.type.ts
+++ b/packages/domain/src/auth/auth.type.ts
@@ -30,7 +30,6 @@ export const AuthUserSchema = z.object({
   id: z.string(),
   email: z.string(),
   name: z.string(),
-  photo: z.string().nullable(),
   provider: AuthProviderSchema,
 });
 

--- a/packages/domain/src/user/user.type.ts
+++ b/packages/domain/src/user/user.type.ts
@@ -2,11 +2,13 @@ export interface User {
   id: string;
   email: string;
   name: string;
-  createdAt: Date;
-  updatedAt: Date;
 }
 
-export interface UserProfile extends User {
-  avatar?: string;
-  bio?: string;
+export interface UserProfile {
+  user: User;
+  subscription: {
+    id: string;
+    name: string;
+    planType: 'FREE' | 'PREMIUM' | 'PRO' | 'BASIC';
+  };
 }


### PR DESCRIPTION
## 설명
인증 로직과 사용자 프로필 관리를 분리하고, API 인터셉터의 토큰 갱신 로직을 전면 개선했습니다. 기존의 복잡한 토큰 갱신 대기열 처리 방식을 단순화하고, 사용자 프로필 정보를 별도 스토어로 분리하여 관심사를 명확히 구분했습니다.

## 추가 내용
- user feature 추가 (프로필 전용 스토어 및 훅)
- QueryClientProvider 추가 (React Query 설정)
- typeUtils 추가 (React Query 타입 유틸리티)
- useFetchUserProfile 훅 추가
- API 토큰 갱신 태스크 큐 시스템 구현

## 변경 내용
- AuthStore에서 사용자 프로필 관리 로직 제거 (ProfileStore로 이동)
- API 인터셉터 토큰 갱신 로직 전면 개선 (대기열 처리 간소화)
- AppState 리스너 제거 (불필요한 백그라운드 처리 로직 삭제)
- 토큰 갱신 시 위치 정보 대신 디바이스 정보 전달
- SignInButton에서 로그인 성공 시 프로필 초기화 추가
- BaseAuthService refreshAccessToken 로직 개선
- AppError에 serverCode 필드 추가 및 토큰 갱신 판단 로직 개선
- ScreenErrorBoundary 및 ErrorFallback 컴포넌트 정리
- API 패키지 user 관련 함수 타입 정리
- Domain 패키지 User 타입에서 photo 필드 제거
- 테스트 코드 업데이트 (photo 필드 제거, 위치→디바이스 정보 변경)
- LoginBottomSheet backdrop 인덱스 조정