### PR TITLE
[feat] 휴대폰 OTP 인증 시스템 구현

### DIFF
--- a/apps/mobile/src/app/navigation/LoggedInNavigator.tsx
+++ b/apps/mobile/src/app/navigation/LoggedInNavigator.tsx
@@ -6,7 +6,10 @@ import { ScreenErrorBoundary } from '@errors/boundaries';
 
 import { ProductBottomSheetProvider } from '@app/screens/product/ProductBottomSheetProvider';
 import { SubscriptionNavigator } from './SubscriptionNavigator/SubscriptionNavigator';
-import { PhoneVerificationScreen } from '@app/screens/auth/PhoneVerificationScreen';
+
+import { OTPVerificationScreen } from '@app/screens/auth/OTPVerificationScreen';
+import { OTPRequestScreen } from '@app/screens/auth/OTPRequestScreen';
+import { Icon, tw } from '@mockly/design-system';
 
 const Stack = createStackNavigator<LoggedInStackParamList>();
 
@@ -18,6 +21,11 @@ export const LoggedInNavigator = () => {
           <ProductBottomSheetProvider>{children}</ProductBottomSheetProvider>
         </ScreenErrorBoundary>
       )}
+      screenOptions={{
+        headerBackImage: () => (
+          <Icon name="chevron-left" style={tw`text-text dark:text-text-dark`} />
+        ),
+      }}
     >
       <Stack.Screen
         name="MainTabs"
@@ -35,11 +43,19 @@ export const LoggedInNavigator = () => {
         options={{ headerShown: false }}
       />
       <Stack.Screen
-        name="PhoneVerification"
-        component={PhoneVerificationScreen}
+        name="OTPRequest"
+        component={OTPRequestScreen}
         options={{
           headerShown: true,
           title: '휴대전화 인증',
+        }}
+      />
+      <Stack.Screen
+        name="OTPVerification"
+        component={OTPVerificationScreen}
+        options={{
+          headerShown: true,
+          title: 'OTP 인증',
         }}
       />
     </Stack.Navigator>

--- a/apps/mobile/src/app/navigation/types.ts
+++ b/apps/mobile/src/app/navigation/types.ts
@@ -9,7 +9,12 @@ export type LoggedInStackParamList = {
   MainTabs: NavigatorScreenParams<TabParamList>;
   Payments: NavigatorScreenParams<PaymentParamList>;
   Subscription: NavigatorScreenParams<SubscriptionParamList>;
-  PhoneVerification: undefined;
+  OTPRequest: undefined;
+  OTPVerification: {
+    phoneNumber: string;
+    expiresIn: number;
+    canResendAfter: number;
+  };
 };
 
 export type TabParamList = {

--- a/apps/mobile/src/app/screens/auth/OTPRequestScreen.tsx
+++ b/apps/mobile/src/app/screens/auth/OTPRequestScreen.tsx
@@ -1,0 +1,147 @@
+import { PropsWithChildren, useCallback, useMemo, useState } from 'react';
+import { TouchableWithoutFeedbackProps, View } from 'react-native';
+import { tw, Text, ScreenFooter, Input, Button } from '@mockly/design-system';
+import { useOTPVerification } from '@features/auth/hooks/useOTPVerification';
+import { useNavigation } from '@react-navigation/native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { PhoneNumber } from '@mockly/domain';
+
+export function OTPRequestScreen() {
+  const navigation = useNavigation();
+  const [phoneNumber, setPhoneNumber] = useState('010-');
+
+  const { sendOTP, isSending, errorMessage } = useOTPVerification({
+    onOTPSent: (expiresInSeconds, canResendAfterSeconds) => {
+      navigation.navigate('OTPVerification', {
+        phoneNumber,
+        expiresIn: expiresInSeconds,
+        canResendAfter: canResendAfterSeconds,
+      });
+    },
+  });
+
+  const isValidPhoneNumber = useMemo(() => {
+    const result = PhoneNumber.schema.safeParse(phoneNumber);
+    return result.success;
+  }, [phoneNumber]);
+
+  const handleSendOTP = useCallback(async () => {
+    if (isValidPhoneNumber) return await sendOTP(phoneNumber);
+  }, [isValidPhoneNumber, phoneNumber, sendOTP]);
+
+  const handleChangePhoneNumber = (text: string) => {
+    const formatted = PhoneNumber.format(text);
+    // "010-" 이하로는 지워지지 않도록
+    if (formatted.length < 4) {
+      setPhoneNumber('010-');
+    } else {
+      setPhoneNumber(formatted);
+    }
+  };
+
+  return (
+    <SafeAreaView style={tw`flex-1`}>
+      <Header
+        title="휴대전화 인증"
+        subTitle="본인 확인을 위해 휴대전화 인증이 필요합니다."
+      />
+      <Content info="인증번호는 하루 최대 5회까지 전송 가능합니다.">
+        <PhoneNumberInput
+          value={phoneNumber}
+          onChangeText={handleChangePhoneNumber}
+          error={errorMessage}
+          editable
+          onSubmit={handleSendOTP}
+        />
+      </Content>
+
+      <Footer>
+        <SendOTPButton
+          onPress={handleSendOTP}
+          disabled={isSending || !isValidPhoneNumber}
+          isLoading={isSending}
+        />
+      </Footer>
+    </SafeAreaView>
+  );
+}
+
+type HeaderProps = {
+  title: string;
+  subTitle: string;
+};
+const Header = ({ title, subTitle }: HeaderProps) => (
+  <View style={tw`mb-10`}>
+    <Text variant="h1" style={tw`mb-3 text-center`}>
+      {title}
+    </Text>
+    <Text variant="body" color="secondary" style={tw`text-center`}>
+      {subTitle}
+    </Text>
+  </View>
+);
+
+type PhoneInputProps = {
+  value: string;
+  onChangeText: (text: string) => void;
+  editable: boolean;
+  error?: string;
+};
+
+const PhoneNumberInput = ({
+  value,
+  onChangeText,
+  editable,
+  error,
+  onSubmit,
+}: PhoneInputProps & { onSubmit?: () => void }) => {
+  return (
+    <Input
+      value={value}
+      onChangeText={onChangeText}
+      placeholder="010-1234-5678"
+      keyboardType="phone-pad"
+      maxLength={13}
+      editable={editable}
+      style={tw`mb-4`}
+      error={error}
+      variant="underlined"
+      returnKeyType="done"
+      onSubmitEditing={onSubmit}
+    />
+  );
+};
+
+// CTA 버튼
+type SendOTPButtonProps = {
+  onPress: TouchableWithoutFeedbackProps['onPress'];
+  isLoading: boolean;
+  disabled: boolean;
+};
+
+const SendOTPButton = ({
+  onPress,
+  isLoading,
+  disabled,
+}: SendOTPButtonProps) => {
+  return (
+    <Button onPress={onPress} disabled={disabled} variant="primary">
+      <Button.Text style={tw`text-lg`}>
+        {isLoading ? '전송중...' : '인증번호 전송'}
+      </Button.Text>
+    </Button>
+  );
+};
+
+const Content = ({ children, info }: PropsWithChildren<{ info: string }>) => (
+  <View style={tw`flex-1 px-6`}>
+    {children}
+    <Text variant="body" color="secondary" style={tw`mb-3`}>
+      {info}
+    </Text>
+  </View>
+);
+
+const Footer = ({ children }: PropsWithChildren) => (
+  <ScreenFooter withShadow>{children}</ScreenFooter>
+);

--- a/apps/mobile/src/app/screens/auth/OTPRequestScreen.tsx
+++ b/apps/mobile/src/app/screens/auth/OTPRequestScreen.tsx
@@ -32,7 +32,7 @@ export function OTPRequestScreen() {
   const handleChangePhoneNumber = (text: string) => {
     const formatted = PhoneNumber.format(text);
     // "010-" 이하로는 지워지지 않도록
-    if (formatted.length < 4) {
+    if (formatted.length <= 4) {
       setPhoneNumber('010-');
     } else {
       setPhoneNumber(formatted);

--- a/apps/mobile/src/app/screens/auth/OTPVerificationScreen.tsx
+++ b/apps/mobile/src/app/screens/auth/OTPVerificationScreen.tsx
@@ -1,9 +1,15 @@
-import { PropsWithChildren, useCallback, useEffect, useState } from 'react';
+import {
+  PropsWithChildren,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import { View } from 'react-native';
 import { tw, Text, ScreenFooter, Button } from '@mockly/design-system';
 import { useOTPTimer } from '@features/auth/hooks/useOTPTimer';
 import { useOTPVerification } from '@features/auth/hooks/useOTPVerification';
-import { useRoute } from '@react-navigation/native';
+import { useNavigation, useRoute } from '@react-navigation/native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { OTPCodeSchema } from '@mockly/domain';
 import { OTPCodeInput } from '@features/auth/components/OTPCodeInput';
@@ -17,6 +23,7 @@ type RouteParams = {
 
 export function OTPVerificationScreen() {
   const route = useRoute();
+  const navigation = useNavigation();
   const params = route.params as RouteParams;
 
   const {
@@ -24,6 +31,7 @@ export function OTPVerificationScreen() {
     expiresIn: initialExpiresIn,
     canResendAfter: initialCanResendAfter,
   } = params;
+
   const [code, setCode] = useState<string>('');
 
   const { expiresIn, canResendAfter, isExpired, startTimer, resetTimer } =
@@ -75,6 +83,9 @@ export function OTPVerificationScreen() {
     },
     [handleVerifyOTP],
   );
+  if (!phoneNumber) {
+    navigation.goBack();
+  }
 
   const handleNumPress = (num: string) => {
     if (code.length < 6) {
@@ -124,11 +135,12 @@ type HeaderProps = {
 };
 
 const Header = ({ title, expiresIn }: HeaderProps) => {
+  const formattedTime = useMemo(() => secondsTommss(expiresIn), [expiresIn]);
   return (
     <View style={tw`px-6 mb-8`}>
       <Text variant="h1">{title}</Text>
       <Text variant="body" color={expiresIn < 60 ? 'error' : 'textSecondary'}>
-        남은 시간: {secondsTommss(expiresIn)}
+        남은 시간: {formattedTime}
       </Text>
     </View>
   );

--- a/apps/mobile/src/app/screens/auth/OTPVerificationScreen.tsx
+++ b/apps/mobile/src/app/screens/auth/OTPVerificationScreen.tsx
@@ -1,0 +1,216 @@
+import { PropsWithChildren, useCallback, useEffect, useState } from 'react';
+import { View } from 'react-native';
+import { tw, Text, ScreenFooter, Button } from '@mockly/design-system';
+import { useOTPTimer } from '@features/auth/hooks/useOTPTimer';
+import { useOTPVerification } from '@features/auth/hooks/useOTPVerification';
+import { useRoute } from '@react-navigation/native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { OTPCodeSchema } from '@mockly/domain';
+import { OTPCodeInput } from '@features/auth/components/OTPCodeInput';
+import { NumPad } from '@features/auth/components/NumPad';
+
+type RouteParams = {
+  phoneNumber: string;
+  expiresIn: number;
+  canResendAfter: number;
+};
+
+export function OTPVerificationScreen() {
+  const route = useRoute();
+  const params = route.params as RouteParams;
+
+  const {
+    phoneNumber,
+    expiresIn: initialExpiresIn,
+    canResendAfter: initialCanResendAfter,
+  } = params;
+  const [code, setCode] = useState<string>('');
+
+  const { expiresIn, canResendAfter, isExpired, startTimer, resetTimer } =
+    useOTPTimer();
+
+  const { sendOTP, verifyOTP, isSending, isVerifying, errorMessage } =
+    useOTPVerification({
+      onOTPSent: (expiresInSeconds, canResendAfterSeconds) => {
+        startTimer(expiresInSeconds, canResendAfterSeconds);
+      },
+      onExpired: () => {
+        resetTimer();
+      },
+    });
+
+  // 처음 화면 진입 시 타이머 시작
+  useEffect(() => {
+    startTimer(initialExpiresIn, initialCanResendAfter);
+  }, [startTimer, initialExpiresIn, initialCanResendAfter]);
+
+  // 핸들러들
+  const handleResendOTPMessage = async () => {
+    await sendOTP(phoneNumber);
+    setCode('');
+  };
+
+  const handleVerifyOTP = useCallback(
+    async (otpCode: string) => {
+      const result = OTPCodeSchema.safeParse(otpCode);
+      if (result.success) {
+        await verifyOTP(phoneNumber, otpCode).finally(() => {
+          setCode('');
+        });
+        return;
+      }
+      setCode('');
+    },
+    [phoneNumber, verifyOTP],
+  );
+
+  const handleChangeCode = useCallback(
+    (text: string) => {
+      const newCode = text.replace(/\D/g, '');
+      setCode(newCode);
+      // 6자리가 모두 입력되면 자동으로 검증
+      if (newCode.length === 6) {
+        handleVerifyOTP(newCode);
+      }
+    },
+    [handleVerifyOTP],
+  );
+
+  const handleNumPress = (num: string) => {
+    if (code.length < 6) {
+      handleChangeCode(code + num);
+    }
+  };
+
+  const handleNumDelete = () => {
+    handleChangeCode(code.slice(0, -1));
+  };
+
+  return (
+    <SafeAreaView style={tw`flex-1`}>
+      <Header
+        title={`문자로 전송된\n인증번호를 입력해주세요.`}
+        expiresIn={expiresIn}
+      />
+
+      <Content>
+        {/* OTP Input */}
+        <OTPInput
+          value={code}
+          onTextChange={handleChangeCode}
+          disabled={isVerifying || isExpired}
+          error={errorMessage}
+        />
+      </Content>
+
+      <Footer>
+        <ResendButton
+          resendRemainingSeconds={canResendAfter}
+          onPress={handleResendOTPMessage}
+          isLoading={isSending}
+        />
+        <NumPad
+          onPress={handleNumPress}
+          onDelete={handleNumDelete}
+          disabled={isVerifying || isExpired}
+        />
+      </Footer>
+    </SafeAreaView>
+  );
+}
+type HeaderProps = {
+  title: string;
+  expiresIn: number;
+};
+
+const Header = ({ title, expiresIn }: HeaderProps) => {
+  return (
+    <View style={tw`px-6 mb-8`}>
+      <Text variant="h1">{title}</Text>
+      <Text variant="body" color={expiresIn < 60 ? 'error' : 'textSecondary'}>
+        남은 시간: {secondsTommss(expiresIn)}
+      </Text>
+    </View>
+  );
+};
+
+function secondsTommss(seconds: number) {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+}
+
+const Footer = ({ children }: PropsWithChildren) => (
+  <ScreenFooter style={tw`flex gap-4`} withShadow>
+    {children}
+  </ScreenFooter>
+);
+
+type ResendButtonProps = {
+  onPress: () => Promise<void>;
+  isLoading: boolean;
+  resendRemainingSeconds: number;
+};
+
+function ResendButton({
+  onPress,
+  isLoading,
+  resendRemainingSeconds,
+}: ResendButtonProps) {
+  const canResend = resendRemainingSeconds > 0;
+  if (canResend) {
+    return (
+      <Text
+        variant="caption"
+        color="textSecondary"
+        style={tw`mt-2 text-center`}
+      >
+        인증번호 재전송 ({resendRemainingSeconds}초)
+      </Text>
+    );
+  }
+
+  return (
+    <Button
+      onPress={onPress}
+      disabled={isLoading}
+      variant="secondary"
+      style={tw`bg-transparent p-0 text-center`}
+    >
+      <Button.Text style={tw`underline text-sm`}>
+        {isLoading ? '전송중...' : '인증번호 재전송'}
+      </Button.Text>
+    </Button>
+  );
+}
+type OTPInputProps = {
+  value: string;
+  onTextChange: (text: string) => void;
+  disabled: boolean;
+  error?: string;
+};
+
+const OTPInput = ({ value, onTextChange, disabled, error }: OTPInputProps) => {
+  return (
+    <>
+      <OTPCodeInput
+        value={value}
+        onChange={onTextChange}
+        length={6}
+        disabled={disabled}
+      />
+      <Text
+        variant="caption"
+        color={error ? 'error' : 'textSecondary'}
+        style={tw` mt-3 mb-3`}
+      >
+        {error ||
+          '* 인증문자가 오지 않으면 수신차단 메시지 또는 스팸함을 확인해 주세요.'}
+      </Text>
+    </>
+  );
+};
+
+const Content = ({ children }: PropsWithChildren) => {
+  return <View style={tw`flex-1 mb-12 px-6`}>{children}</View>;
+};

--- a/apps/mobile/src/app/screens/product/ProductScreen.tsx
+++ b/apps/mobile/src/app/screens/product/ProductScreen.tsx
@@ -14,6 +14,7 @@ import { ProductList } from './components/ProductList';
 import { ProductDetail } from './components/ProductDetail';
 import { ProductSummary } from './components/ProductSummary';
 import { PurchaseCTA } from './components/PurchaseCTA';
+import { WithPhoneVerification } from '@features/auth/components/WithPhoneVerification';
 
 export interface PlanSelectionBottomSheetProps {
   bottomSheetRef: RefObject<GoHomeBottomSheet | null>;
@@ -93,11 +94,13 @@ export const ProductsScreen = ({
       isClosable={isNotOnPaymentProcess}
       ref={bottomSheetRef}
       FooterComponent={
-        <PurchaseCTA
-          onPress={handlePurchase}
-          disabled={isActionDisabled}
-          content={PURCHASE_CTA_TEXT[actionType]}
-        />
+        <WithPhoneVerification>
+          <PurchaseCTA
+            onPress={handlePurchase}
+            disabled={isActionDisabled}
+            content={PURCHASE_CTA_TEXT[actionType]}
+          />
+        </WithPhoneVerification>
       }
     >
       <BottomSheetScrollView

--- a/apps/mobile/src/app/screens/subscription/SubscriptionChangeScreen.tsx
+++ b/apps/mobile/src/app/screens/subscription/SubscriptionChangeScreen.tsx
@@ -41,7 +41,7 @@ export const SubscriptionChangeScreen = ({ route }: Props) => {
     if (subscription.type === 'Free') {
       navigation.navigate('MainTabs', { screen: 'Home' });
     }
-  }, []);
+  }, [navigation, subscription]);
   if (subscription.type === 'Free') {
     return null;
   }

--- a/apps/mobile/src/configs/queryClient/QueryKeys.ts
+++ b/apps/mobile/src/configs/queryClient/QueryKeys.ts
@@ -3,6 +3,15 @@ import api from '@mockly/api';
 
 // if you prefer to declare everything in one file
 export const queries = createQueryKeyStore({
+  auth: {
+    all: null,
+    postOTPMessage: () => ({
+      queryKey: ['OPT-Message'],
+    }),
+    postOTPVerification: () => ({
+      queryKey: ['OPT-Verify'],
+    }),
+  },
   user: {
     all: null,
     profile: () => ({

--- a/apps/mobile/src/features/auth/components/NumPad.tsx
+++ b/apps/mobile/src/features/auth/components/NumPad.tsx
@@ -1,0 +1,100 @@
+import { FlatList, View, useWindowDimensions } from 'react-native';
+import { tw, Button, Icon } from '@mockly/design-system';
+
+interface NumPadProps {
+  onPress: (value: string) => void;
+  onDelete: () => void;
+  disabled?: boolean;
+}
+
+const NUMBERS = [
+  '1',
+  '2',
+  '3',
+  '4',
+  '5',
+  '6',
+  '7',
+  '8',
+  '9',
+  '',
+  '0',
+  'delete',
+] as const;
+
+export function NumPad({ onPress, onDelete, disabled = false }: NumPadProps) {
+  const { width: screenWidth } = useWindowDimensions();
+  const HORIZONTAL_PADDING = 48; // ScreenFooter px-6 * 2 = 24 * 2
+  const GAP_SIZE = 12; // gap-3
+  const TOTAL_GAP = GAP_SIZE * 2; // 3개 열 사이의 간격
+  const MAX_WIDTH = 400; // 최대 너비 제한
+  const availableWidth = Math.min(screenWidth - HORIZONTAL_PADDING, MAX_WIDTH);
+  const ITEM_WIDTH = (availableWidth - TOTAL_GAP) / 3;
+  const ITEM_HEIGHT = 56; // 고정 높이
+  const handlePress = (value: string) => {
+    if (disabled) return;
+
+    if (value === 'delete') {
+      onDelete();
+    } else if (value !== '') {
+      onPress(value);
+    }
+  };
+
+  const renderItem = ({ item }: { item: (typeof NUMBERS)[number] }) => {
+    const num = item;
+
+    if (num === '') {
+      return <View style={{ width: ITEM_WIDTH, height: ITEM_HEIGHT }} />;
+    }
+
+    if (num === 'delete') {
+      return (
+        <Button
+          variant="primary"
+          size="large"
+          onPress={() => handlePress(num)}
+          disabled={disabled}
+          style={[
+            tw`items-center justify-center`,
+            { width: ITEM_WIDTH, height: ITEM_HEIGHT },
+          ]}
+        >
+          <Button.Icon>
+            <Icon
+              name="delete"
+              variant={'text'}
+              style={tw`${disabled ? 'opacity-50' : ''}`}
+            />
+          </Button.Icon>
+        </Button>
+      );
+    }
+
+    return (
+      <Button
+        onPress={() => handlePress(num)}
+        disabled={disabled}
+        variant="outline"
+        style={[
+          tw`items-center justify-center rounded-xl ${disabled ? 'opacity-50' : ''}`,
+          { width: ITEM_WIDTH, height: ITEM_HEIGHT },
+        ]}
+      >
+        <Button.Text style={tw`text-2xl font-medium`}>{num}</Button.Text>
+      </Button>
+    );
+  };
+
+  return (
+    <FlatList
+      data={NUMBERS}
+      renderItem={renderItem}
+      keyExtractor={(item, index) => `numpad-${index}`}
+      numColumns={3}
+      columnWrapperStyle={tw`gap-3 justify-center`}
+      contentContainerStyle={tw`gap-3`}
+      scrollEnabled={false}
+    />
+  );
+}

--- a/apps/mobile/src/features/auth/components/NumPad.tsx
+++ b/apps/mobile/src/features/auth/components/NumPad.tsx
@@ -55,6 +55,9 @@ export function NumPad({ onPress, onDelete, disabled = false }: NumPadProps) {
           size="large"
           onPress={() => handlePress(num)}
           disabled={disabled}
+          accessible={true}
+          accessibilityLabel={`삭제`}
+          accessibilityRole="button"
           style={[
             tw`items-center justify-center`,
             { width: ITEM_WIDTH, height: ITEM_HEIGHT },
@@ -76,6 +79,9 @@ export function NumPad({ onPress, onDelete, disabled = false }: NumPadProps) {
         onPress={() => handlePress(num)}
         disabled={disabled}
         variant="outline"
+        accessible={true}
+        accessibilityLabel={`숫자 ${num}`}
+        accessibilityRole="button"
         style={[
           tw`items-center justify-center rounded-xl ${disabled ? 'opacity-50' : ''}`,
           { width: ITEM_WIDTH, height: ITEM_HEIGHT },

--- a/apps/mobile/src/features/auth/components/OTPCodeInput.tsx
+++ b/apps/mobile/src/features/auth/components/OTPCodeInput.tsx
@@ -1,0 +1,140 @@
+import { useRef, useState, useEffect } from 'react';
+import {
+  View,
+  TextInput,
+  Pressable,
+  Text,
+  TextInputKeyPressEvent,
+} from 'react-native';
+import { tw } from '@mockly/design-system';
+import { cn } from '@mockly/utils';
+
+interface OTPCodeInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  length?: number;
+  disabled?: boolean;
+}
+
+export function OTPCodeInput({
+  value,
+  onChange,
+  length = 6,
+  disabled = false,
+}: OTPCodeInputProps) {
+  const [focusedIndex, setFocusedIndex] = useState<number | null>(null);
+  const inputRefs = useRef<(TextInput | null)[]>([]);
+
+  const digits = value.split('');
+
+  // 처음 마운트될 때 첫 번째 칸에 자동 포커스
+  useEffect(() => {
+    if (!disabled && inputRefs.current[0]) {
+      setTimeout(() => {
+        inputRefs.current[0]?.focus();
+      }, 100);
+    }
+  }, [disabled]);
+
+  const handlePress = (index: number) => {
+    if (disabled) return;
+    inputRefs.current[index]?.focus();
+  };
+
+  const handleChange = (text: string, index: number) => {
+    const numericText = text.replace(/\D/g, '');
+
+    if (numericText.length === 0) {
+      return;
+    }
+
+    if (numericText.length === 1) {
+      // 한 자리 입력 - 현재 값에 추가
+      const newValue = value + numericText;
+      onChange(newValue.slice(0, length));
+
+      // 다음 칸으로 이동
+      if (index < length - 1) {
+        inputRefs.current[index + 1]?.focus();
+      }
+    } else {
+      // 여러 자리 붙여넣기
+      onChange(numericText.slice(0, length));
+
+      // 마지막 입력된 칸으로 이동
+      const lastIndex = Math.min(numericText.length - 1, length - 1);
+      inputRefs.current[lastIndex]?.focus();
+    }
+  };
+
+  const handleKeyPress = (e: TextInputKeyPressEvent, index: number) => {
+    if (e.nativeEvent.key === 'Backspace') {
+      e.preventDefault();
+
+      if (digits[index]) {
+        // 현재 칸에 숫자가 있으면 지우기
+        onChange(value.slice(0, -1));
+      } else if (index > 0) {
+        // 현재 칸이 비어있으면 이전 칸으로 이동하고 지우기
+        onChange(value.slice(0, -1));
+        inputRefs.current[index - 1]?.focus();
+      }
+    }
+  };
+
+  return (
+    <View style={tw`flex-row justify-between gap-2`}>
+      {Array.from({ length }).map((_, index) => {
+        const isFocused = focusedIndex === index;
+        const hasValue = !!digits[index];
+
+        return (
+          <Pressable
+            key={`$otp-code-${index}`}
+            onPress={() => handlePress(index)}
+            style={tw`flex-1 aspect-square`}
+          >
+            <View
+              style={tw`${cn(
+                'flex-1 items-center justify-center border-2 rounded-lg',
+                {
+                  'border-primary bg-surface dark:bg-surface-dark':
+                    isFocused || (hasValue && !isFocused),
+                  'border-border dark:border-border-dark bg-surface dark:bg-surface-dark':
+                    !hasValue && !isFocused,
+                  'opacity-50': disabled,
+                },
+              )}`}
+            >
+              <TextInput
+                ref={ref => {
+                  inputRefs.current[index] = ref;
+                }}
+                value={digits[index] || ''}
+                onChangeText={text => handleChange(text, index)}
+                onKeyPress={e => handleKeyPress(e, index)}
+                onFocus={() => setFocusedIndex(index)}
+                onBlur={() => setFocusedIndex(null)}
+                keyboardType="number-pad"
+                maxLength={1}
+                editable={!disabled}
+                selectTextOnFocus
+                showSoftInputOnFocus={false}
+                caretHidden
+                style={tw`absolute inset-0 text-center text-2xl text-text dark:text-text-dark font-bold opacity-0`}
+              />
+              {/* 시각적 텍스트 표시 */}
+              {digits[index] && (
+                <Text
+                  style={tw`text-2xl font-bold text-text dark:text-text-dark`}
+                >
+                  {digits[index]}
+                </Text>
+              )}
+            </View>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}

--- a/apps/mobile/src/features/auth/components/OTPCodeInput.tsx
+++ b/apps/mobile/src/features/auth/components/OTPCodeInput.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useEffect } from 'react';
+import { useRef, useState, useCallback } from 'react';
 import {
   View,
   TextInput,
@@ -8,6 +8,7 @@ import {
 } from 'react-native';
 import { tw } from '@mockly/design-system';
 import { cn } from '@mockly/utils';
+import { useFocusEffect } from '@react-navigation/native';
 
 interface OTPCodeInputProps {
   value: string;
@@ -27,14 +28,15 @@ export function OTPCodeInput({
 
   const digits = value.split('');
 
-  // 처음 마운트될 때 첫 번째 칸에 자동 포커스
-  useEffect(() => {
-    if (!disabled && inputRefs.current[0]) {
-      setTimeout(() => {
+  useFocusEffect(
+    useCallback(() => {
+      const id = setTimeout(() => {
         inputRefs.current[0]?.focus();
-      }, 100);
-    }
-  }, [disabled]);
+      }, 0);
+
+      return () => clearTimeout(id);
+    }, []),
+  );
 
   const handlePress = (index: number) => {
     if (disabled) return;

--- a/apps/mobile/src/features/auth/components/WithPhoneVerification.tsx
+++ b/apps/mobile/src/features/auth/components/WithPhoneVerification.tsx
@@ -1,5 +1,5 @@
-import { ReactNode } from 'react';
-import { Alert } from 'react-native';
+import React, { ReactNode } from 'react';
+import { Alert, PressableProps } from 'react-native';
 import { useUserProfile } from '@features/user/hooks';
 import { useNavigation } from '@react-navigation/native';
 
@@ -60,27 +60,14 @@ export function WithPhoneVerification({
     // onPress를 가로채지 않고 그냥 렌더링 (부모가 직접 처리)
     return <>{children}</>;
   }
+  if (React.isValidElement<PressableProps>(children)) {
+    return React.cloneElement(children, {
+      onPress: handleUnverified,
+    });
+  }
 
   // onPress를 가로채서 인증 확인
-  return (
-    <>
-      {typeof children === 'object' &&
-      children !== null &&
-      'props' in children &&
-      typeof children.props === 'object' &&
-      children.props !== null
-        ? {
-            ...children,
-            props: {
-              ...children.props,
-              onPress: () => {
-                handleUnverified();
-              },
-            },
-          }
-        : children}
-    </>
-  );
+  return children;
 }
 
 export function usePhoneVerification() {

--- a/apps/mobile/src/features/auth/components/WithPhoneVerification.tsx
+++ b/apps/mobile/src/features/auth/components/WithPhoneVerification.tsx
@@ -1,0 +1,122 @@
+import { ReactNode } from 'react';
+import { Alert } from 'react-native';
+import { useUserProfile } from '@features/user/hooks';
+import { useNavigation } from '@react-navigation/native';
+
+interface WithPhoneVerificationProps {
+  children: ReactNode;
+  /**
+   * 인증이 필요할 때 표시할 메시지
+   * @default "이 기능을 사용하려면 휴대폰 인증이 필요합니다."
+   */
+  message?: string;
+  /**
+   * 인증 실패 시 Alert 대신 커스텀 핸들러 사용
+   */
+  onUnverified?: () => void;
+  /**
+   * 자식 컴포넌트의 onPress를 가로챌지 여부
+   * @default true
+   */
+  interceptPress?: boolean;
+}
+
+export function WithPhoneVerification({
+  children,
+  message = '이 기능을 사용하려면 휴대폰 인증이 필요합니다.',
+  onUnverified,
+  interceptPress = true,
+}: WithPhoneVerificationProps) {
+  const { isPhoneVerified } = useUserProfile();
+  const navigation = useNavigation();
+
+  const handleUnverified = () => {
+    if (onUnverified) {
+      onUnverified();
+      return;
+    }
+
+    Alert.alert('휴대폰 인증 필요', message, [
+      {
+        text: '취소',
+        style: 'cancel',
+      },
+      {
+        text: '인증하기',
+        onPress: () => {
+          navigation.navigate('OTPRequest');
+        },
+      },
+    ]);
+  };
+
+  // 이미 인증된 경우 그대로 렌더링
+  if (isPhoneVerified) {
+    return <>{children}</>;
+  }
+
+  // 인증되지 않은 경우
+  if (!interceptPress) {
+    // onPress를 가로채지 않고 그냥 렌더링 (부모가 직접 처리)
+    return <>{children}</>;
+  }
+
+  // onPress를 가로채서 인증 확인
+  return (
+    <>
+      {typeof children === 'object' &&
+      children !== null &&
+      'props' in children &&
+      typeof children.props === 'object' &&
+      children.props !== null
+        ? {
+            ...children,
+            props: {
+              ...children.props,
+              onPress: () => {
+                handleUnverified();
+              },
+            },
+          }
+        : children}
+    </>
+  );
+}
+
+export function usePhoneVerification() {
+  const { isPhoneVerified } = useUserProfile();
+  const navigation = useNavigation();
+
+  const requirePhoneVerification = (
+    message: string = '이 기능을 사용하려면 휴대폰 인증이 필요합니다.',
+  ): boolean => {
+    if (isPhoneVerified) {
+      return true;
+    }
+
+    Alert.alert('휴대폰 인증 필요', message, [
+      {
+        text: '취소',
+        style: 'cancel',
+      },
+      {
+        text: '인증하기',
+        onPress: () => {
+          navigation.navigate('OTPRequest');
+        },
+      },
+    ]);
+
+    return false;
+  };
+
+  const navigateToPhoneVerification = () => {
+    navigation.navigate('OTPRequest');
+  };
+
+  return {
+    isPhoneVerified,
+    requirePhoneVerification,
+    navigateToPhoneVerification,
+  };
+}

--- a/apps/mobile/src/features/auth/hooks.ts
+++ b/apps/mobile/src/features/auth/hooks.ts
@@ -62,7 +62,7 @@ export const useInitializeAuthAndGetProfile = () => {
 
     const profile_user = { ...profile.user, provider: storedProvider };
     const profile_subscription = profile.subscription;
-    setProfile(profile_user, profile_subscription);
+    setProfile(profile_user, profile_subscription, profile.isPhoneVerified);
   };
 
   return initializeAuthAndGetProfile;
@@ -97,7 +97,7 @@ export const useSignIn = () => {
       }
       const profile_user = { ...profile.user, provider };
       const profile_subscription = profile.subscription;
-      setProfile(profile_user, profile_subscription);
+      setProfile(profile_user, profile_subscription, profile.isPhoneVerified);
       return profile_user.name;
     },
   });

--- a/apps/mobile/src/features/auth/hooks/useOTPTimer.ts
+++ b/apps/mobile/src/features/auth/hooks/useOTPTimer.ts
@@ -1,65 +1,37 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 
-interface UseOTPTimerReturn {
-  expiresIn: number;
-  canResendAfter: number;
-  isExpired: boolean;
-  startTimer: (expiresInSeconds: number, canResendAfterSeconds: number) => void;
-  resetTimer: () => void;
-}
-
-export function useOTPTimer(): UseOTPTimerReturn {
-  const [expiresIn, setExpiresIn] = useState(0);
-  const [canResendAfter, setCanResendAfter] = useState(0);
-
-  // OTP 만료 타이머
-  useEffect(() => {
-    if (expiresIn <= 0) return;
-
-    const timer = setInterval(() => {
-      setExpiresIn(prev => {
-        if (prev <= 1) return 0;
-        return prev - 1;
-      });
-    }, 1000);
-
-    return () => clearInterval(timer);
-  }, [expiresIn]);
-
-  // 재전송 대기 타이머
-  useEffect(() => {
-    if (canResendAfter <= 0) return;
-
-    const timer = setInterval(() => {
-      setCanResendAfter(prev => {
-        if (prev <= 1) return 0;
-        return prev - 1;
-      });
-    }, 1000);
-
-    return () => clearInterval(timer);
-  }, [canResendAfter]);
-
-  const startTimer = useCallback(
-    (expiresInSeconds: number, canResendAfterSeconds: number) => {
-      setExpiresIn(expiresInSeconds);
-      setCanResendAfter(canResendAfterSeconds);
-    },
-    [],
-  );
-
-  const resetTimer = useCallback(() => {
-    setExpiresIn(0);
-    setCanResendAfter(0);
-  }, []);
-
-  const isExpired = expiresIn === 0;
+export function useOTPTimer() {
+  const expires = useTimer();
+  const resend = useTimer();
 
   return {
-    expiresIn,
-    canResendAfter,
-    isExpired,
-    startTimer,
-    resetTimer,
+    expiresIn: expires.seconds,
+    canResendAfter: resend.seconds,
+    isExpired: expires.seconds === 0,
+    startTimer: (expiresInSeconds: number, canResendAfterSeconds: number) => {
+      expires.setSeconds(expiresInSeconds);
+      resend.setSeconds(canResendAfterSeconds);
+    },
+    resetTimer: () => {
+      expires.setSeconds(0);
+      resend.setSeconds(0);
+    },
   };
+}
+
+function useTimer() {
+  const [seconds, setSeconds] = useState(0);
+
+  const isCounting = seconds > 0;
+  useEffect(() => {
+    if (!isCounting) return;
+
+    const timer = setInterval(() => {
+      setSeconds(prev => Math.max(0, prev - 1));
+    }, 1000);
+
+    return () => clearInterval(timer);
+  }, [isCounting]);
+
+  return { seconds, setSeconds };
 }

--- a/apps/mobile/src/features/auth/hooks/useOTPTimer.ts
+++ b/apps/mobile/src/features/auth/hooks/useOTPTimer.ts
@@ -1,0 +1,65 @@
+import { useState, useEffect, useCallback } from 'react';
+
+interface UseOTPTimerReturn {
+  expiresIn: number;
+  canResendAfter: number;
+  isExpired: boolean;
+  startTimer: (expiresInSeconds: number, canResendAfterSeconds: number) => void;
+  resetTimer: () => void;
+}
+
+export function useOTPTimer(): UseOTPTimerReturn {
+  const [expiresIn, setExpiresIn] = useState(0);
+  const [canResendAfter, setCanResendAfter] = useState(0);
+
+  // OTP 만료 타이머
+  useEffect(() => {
+    if (expiresIn <= 0) return;
+
+    const timer = setInterval(() => {
+      setExpiresIn(prev => {
+        if (prev <= 1) return 0;
+        return prev - 1;
+      });
+    }, 1000);
+
+    return () => clearInterval(timer);
+  }, [expiresIn]);
+
+  // 재전송 대기 타이머
+  useEffect(() => {
+    if (canResendAfter <= 0) return;
+
+    const timer = setInterval(() => {
+      setCanResendAfter(prev => {
+        if (prev <= 1) return 0;
+        return prev - 1;
+      });
+    }, 1000);
+
+    return () => clearInterval(timer);
+  }, [canResendAfter]);
+
+  const startTimer = useCallback(
+    (expiresInSeconds: number, canResendAfterSeconds: number) => {
+      setExpiresIn(expiresInSeconds);
+      setCanResendAfter(canResendAfterSeconds);
+    },
+    [],
+  );
+
+  const resetTimer = useCallback(() => {
+    setExpiresIn(0);
+    setCanResendAfter(0);
+  }, []);
+
+  const isExpired = expiresIn === 0;
+
+  return {
+    expiresIn,
+    canResendAfter,
+    isExpired,
+    startTimer,
+    resetTimer,
+  };
+}

--- a/apps/mobile/src/features/auth/hooks/useOTPVerification.ts
+++ b/apps/mobile/src/features/auth/hooks/useOTPVerification.ts
@@ -1,0 +1,109 @@
+import { useState } from 'react';
+import { Alert } from 'react-native';
+import { useMutation } from '@tanstack/react-query';
+import { useNavigation } from '@react-navigation/native';
+import api from '@mockly/api';
+import {
+  OTPSendErrorCode,
+  OTPVerifyErrorCode,
+  getOTPErrorMessage,
+  extractRemainingAttempts,
+} from '@mockly/domain';
+import { deviceInfo } from '@libs/deviceInfo';
+import { useProfileStore } from '@features/user';
+import { AppError } from '@errors/AppError';
+
+interface UseOTPVerificationOptions {
+  onOTPSent?: (expiresIn: number, canResendAfter: number) => void;
+  onVerifySuccess?: () => void;
+  onExpired?: () => void;
+}
+
+export function useOTPVerification({
+  onOTPSent,
+  onVerifySuccess,
+  onExpired,
+}: UseOTPVerificationOptions = {}) {
+  const navigation = useNavigation();
+  const [errorMessage, setErrorMessage] = useState('');
+  const [remainingAttempts, setRemainingAttempts] = useState<number | null>(
+    null,
+  );
+  const verifyPhone = useProfileStore(state => state.verifyPhone);
+  // OTP 전송 Mutation
+  const { mutateAsync: sendOTP, isPending: isSending } = useMutation({
+    mutationFn: api.auth.postOTPMessage,
+    onSuccess: res => {
+      onOTPSent?.(res.expiresIn, res.canResendAfter);
+      setRemainingAttempts(null);
+      setErrorMessage('');
+    },
+    onError: error => {
+      if (AppError.isApiError(error)) {
+        const errorCode = error.serverCode as OTPSendErrorCode;
+        const message = error.message || '';
+        setErrorMessage(getOTPErrorMessage(errorCode, message));
+      } else {
+        setErrorMessage('인증번호 전송에 실패했습니다. 다시 시도해주세요.');
+      }
+    },
+  });
+
+  // OTP 검증 Mutation
+  const { mutateAsync: verifyOTP, isPending: isVerifying } = useMutation({
+    mutationFn: api.auth.postOTPVerification,
+    onSuccess: () => {
+      Alert.alert('인증 완료', '휴대폰 인증이 완료되었습니다.', [
+        {
+          text: '확인',
+          onPress: () => {
+            verifyPhone(true);
+            onVerifySuccess?.();
+            navigation.navigate('MainTabs', { screen: 'Home' });
+          },
+        },
+      ]);
+    },
+    onError: error => {
+      if (AppError.isApiError(error)) {
+        const errorCode = error.serverCode;
+        const errorMessage = error.message || '';
+        switch (errorCode) {
+          case OTPVerifyErrorCode.INVALID_CODE: {
+            const remaining = extractRemainingAttempts(errorMessage);
+            setRemainingAttempts(remaining);
+            break;
+          }
+          case OTPVerifyErrorCode.CODE_EXPIRED:
+            onExpired?.();
+            break;
+        }
+        setErrorMessage(errorMessage);
+      } else {
+        console.error('Unexpected error during OTP verification:', error);
+        setErrorMessage('인증에 실패했습니다. 다시 시도해주세요.');
+      }
+    },
+  });
+
+  const handleSendOTP = async (phoneNumber: string) => {
+    await sendOTP({ phoneNumber });
+  };
+
+  const handleVerifyOTP = async (phoneNumber: string, code: string) => {
+    const deviceId = deviceInfo.getDevice();
+    await verifyOTP({ phoneNumber, code, deviceId });
+  };
+
+  const clearError = () => setErrorMessage('');
+
+  return {
+    sendOTP: handleSendOTP,
+    verifyOTP: handleVerifyOTP,
+    isSending,
+    isVerifying,
+    errorMessage,
+    remainingAttempts,
+    clearError,
+  };
+}

--- a/apps/mobile/src/features/auth/hooks/useOTPVerification.ts
+++ b/apps/mobile/src/features/auth/hooks/useOTPVerification.ts
@@ -80,7 +80,6 @@ export function useOTPVerification({
         }
         setErrorMessage(errorMessage);
       } else {
-        console.error('Unexpected error during OTP verification:', error);
         setErrorMessage('인증에 실패했습니다. 다시 시도해주세요.');
       }
     },

--- a/apps/mobile/src/features/user/hooks.ts
+++ b/apps/mobile/src/features/user/hooks.ts
@@ -11,11 +11,12 @@ export const useInitializeProfile = () => {
 };
 
 export const useUserProfile = () => {
-  const { user, subscription, isSigned } = useProfileStore(
+  const { user, subscription, isSigned, isPhoneVerified } = useProfileStore(
     useShallow(state => ({
       user: state.user,
       subscription: state.subscription,
       isSigned: state.isSigned,
+      isPhoneVerified: state.isPhoneVerified,
     })),
   );
   if (!user || !subscription || !isSigned) {
@@ -26,5 +27,5 @@ export const useUserProfile = () => {
     );
   }
 
-  return { user, subscription, isSigned };
+  return { user, subscription, isSigned, isPhoneVerified };
 };

--- a/apps/mobile/src/features/user/store.ts
+++ b/apps/mobile/src/features/user/store.ts
@@ -7,18 +7,25 @@ type SignedProfileState = {
   user: User;
   subscription: ProfileSubscription;
   isSigned: true;
+  isPhoneVerified: boolean;
 };
 type UnSignedProfileState = {
   user: null;
   subscription: null;
   isSigned: false;
+  isPhoneVerified: false;
 };
 
 type ProfileSubscription = UserProfile['subscription'];
 
 interface ProfileActions {
   clearProfile: () => void;
-  setProfile: (user: User, subscription: ProfileSubscription) => void;
+  setProfile: (
+    user: User,
+    subscription: ProfileSubscription,
+    isPhoneVerified: boolean,
+  ) => void;
+  verifyPhone: (isVerified: boolean) => void;
 }
 
 type ProfileStore = ProfileState & ProfileActions;
@@ -26,11 +33,14 @@ type ProfileStore = ProfileState & ProfileActions;
 export const useProfileStore = create<ProfileStore>(set => ({
   ...initialStoreState,
 
-  setProfile: (user, subscription) => {
-    set({ user, subscription, isSigned: true });
+  setProfile: (user, subscription, isPhoneVerified) => {
+    set({ user, subscription, isSigned: true, isPhoneVerified });
   },
   clearProfile: () => {
     set(initialStoreState);
+  },
+  verifyPhone: (isVerified: boolean) => {
+    set({ isPhoneVerified: isVerified });
   },
 }));
 
@@ -38,4 +48,5 @@ const initialStoreState: UnSignedProfileState = {
   user: null,
   subscription: null,
   isSigned: false,
+  isPhoneVerified: false,
 };

--- a/packages/api/src/auth/index.ts
+++ b/packages/api/src/auth/index.ts
@@ -1,3 +1,5 @@
 export * from './logout';
 export * from './renewalToken';
 export * from './loginWithPKCECode';
+export * from './postOTPMessage';
+export * from './postOTPVerification';

--- a/packages/api/src/auth/postOTPMessage.ts
+++ b/packages/api/src/auth/postOTPMessage.ts
@@ -16,6 +16,7 @@ type ResponseDTO = {
 
 export const postOTPMessage = async (req: RequestDTO) => {
   const res = await apiClient.post<ResponseDTO>('/api/auth/phone/send', req).catch(() => {
+    // TODO: API 없어서 Mock. MSW 추가 예정
     return {
       data: {
         expiresIn: 180,

--- a/packages/api/src/auth/postOTPMessage.ts
+++ b/packages/api/src/auth/postOTPMessage.ts
@@ -1,0 +1,29 @@
+import z from 'zod';
+import { apiClient } from '../client';
+
+type RequestDTO = {
+  phoneNumber: string;
+};
+const RequestDTO = z.object({
+  phoneNumber: z.string(),
+});
+
+type ResponseDTO = {
+  expiresIn: 180; // OTP 유효시간 (3분, 초 단위)
+  canResendAfter: 30; // 재전송 가능 시간 (30초, 초 단위)
+  isFirstTime: boolean; // 최초 인증 여부
+};
+
+export const postOTPMessage = async (req: RequestDTO) => {
+  const res = await apiClient.post<ResponseDTO>('/api/auth/phone/send', req).catch(() => {
+    return {
+      data: {
+        expiresIn: 180,
+        canResendAfter: 30,
+        isFirstTime: true,
+      },
+    };
+  });
+
+  return res.data;
+};

--- a/packages/api/src/auth/postOTPVerification.ts
+++ b/packages/api/src/auth/postOTPVerification.ts
@@ -1,0 +1,33 @@
+import { apiClient } from '../client';
+
+type RequestDTO = {
+  phoneNumber: string;
+  code: string;
+  deviceId: string;
+};
+
+export const postOTPVerification = async (req: RequestDTO) => {
+  const res = await apiClient.post<null>('/api/auth/phone/verify', req).catch(err => {
+    throw err;
+    // 테스트 위해 남겨두기
+    // err.isAxiosError = true;
+    // err.response = {
+    //   data: {
+    //     data: null,
+    //     success: false,
+    //     error: 'INVALID_CODE',
+    //     message: '인증 번호가 일치하지 않습니다. (남은 시도: 4회)',
+    //   },
+    //   headers: {},
+    //   status: 500,
+    //   statusText: '',
+    // };
+
+    // throw err;
+    return {
+      success: true,
+    };
+  });
+
+  return res.success;
+};

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -6,6 +6,13 @@ export interface ApiResponse<T = unknown> {
   timestamp: number;
 }
 
+export interface ApiErrorResponse {
+  error: string;
+  message: string;
+  success: false;
+  timestamp: number;
+}
+
 export type Pageable<T = unknown> = T & {
   pagination: {
     page: number /** 기본값 = 1, 1부터 시작 */;

--- a/packages/api/src/user/getUserProfile.ts
+++ b/packages/api/src/user/getUserProfile.ts
@@ -22,5 +22,6 @@ export async function getUserProfile(): Promise<UserProfile> {
         price: '0',
       },
     },
+    isPhoneVerified: false,
   };
 }

--- a/packages/api/src/user/updateUserProfile.ts
+++ b/packages/api/src/user/updateUserProfile.ts
@@ -46,5 +46,6 @@ export async function updateUserProfile(
       cancelAtPeriodEnd: false,
       canceledAt: null,
     },
+    isPhoneVerified: false,
   };
 }

--- a/packages/design-system/src/components/Input/Input.tsx
+++ b/packages/design-system/src/components/Input/Input.tsx
@@ -1,14 +1,19 @@
-import React, { useId, useMemo } from 'react';
+import React, { RefObject, useId, useMemo } from 'react';
 import { TextInput, View, Text, TextInputProps, ViewStyle } from 'react-native';
 import { cva } from 'cva';
 import { tw } from '../../lib/tw';
 import { colors } from '../../theme';
 
 const inputVariants = cva({
-  base: 'bg-surface dark:bg-surface border border-border dark:border-border rounded-md px-md py-md text-md text-text dark:text-text',
+  base: ' px-md py-md text-md text-text dark:text-text-dark',
   variants: {
     hasError: {
       true: 'border-error dark:border-error',
+    },
+    variant: {
+      outlined: 'border bg-surface dark:bg-surface border-border dark:border-border',
+      rounded: 'border bg-surface dark:bg-surface border-border dark:border-border rounded-md',
+      underlined: 'border-b border-b-border',
     },
   },
 });
@@ -18,6 +23,8 @@ export interface InputProps extends TextInputProps {
   error?: string;
   containerStyle?: ViewStyle;
   placeholderTextColor?: string;
+  ref?: RefObject<TextInput | null>;
+  variant?: 'outlined' | 'underlined' | 'rounded';
 }
 
 export const Input: React.FC<InputProps> = ({
@@ -26,17 +33,16 @@ export const Input: React.FC<InputProps> = ({
   containerStyle,
   style,
   placeholderTextColor,
+  variant = 'outlined',
   ...props
 }) => {
-  const inputStyle = useMemo(() => tw.style(inputVariants({ hasError: !!error })), [error]);
-
   const inputId = useId();
   const labelId = `${inputId}-label`;
   const errorId = `${inputId}-error`;
   const placeholderColor = useMemo(
     () =>
       placeholderTextColor ??
-      (tw.color('text-textSecondary dark:text-textSecondary') || colors.textSecondary),
+      (tw.color('text-text-secondary dark:text-text-secondary') || colors.textSecondary),
     [placeholderTextColor]
   );
   return (
@@ -45,7 +51,7 @@ export const Input: React.FC<InputProps> = ({
         <Text style={tw`text-sm font-medium text-text dark:text-text-dark mb-xs`}>{label}</Text>
       )}
       <TextInput
-        style={[inputStyle, style]}
+        style={[tw`${inputVariants({ hasError: !!error, variant })}`, style]}
         placeholderTextColor={placeholderColor}
         accessible={true}
         accessibilityLabel={label ? `${label}${error ? `, 오류: ${error}` : ''}` : undefined}

--- a/packages/design-system/src/components/ScreenFooter/ScreenFooter.tsx
+++ b/packages/design-system/src/components/ScreenFooter/ScreenFooter.tsx
@@ -1,0 +1,35 @@
+import { StyleProp, View, ViewStyle } from 'react-native';
+import { ReactNode } from 'react';
+import tw from '../../lib/tw';
+import { cn } from '@mockly/utils';
+
+interface ScreenFooterProps {
+  children: ReactNode;
+  withBackground?: boolean;
+  withShadow?: boolean;
+  withBorder?: boolean;
+  style?: StyleProp<ViewStyle>;
+}
+
+export function ScreenFooter({
+  children,
+  withBackground = false,
+  withShadow = false,
+  withBorder = false,
+  style,
+}: ScreenFooterProps) {
+  return (
+    <View
+      style={[
+        tw`${cn('px-6 py-4', {
+          'bg-black': withBackground,
+          'shadow-lg': withShadow,
+          'border-t border-gray-800': withBorder,
+        })}`,
+        style,
+      ]}
+    >
+      {children}
+    </View>
+  );
+}

--- a/packages/design-system/src/components/ScreenFooter/ScreenFooter.tsx
+++ b/packages/design-system/src/components/ScreenFooter/ScreenFooter.tsx
@@ -22,9 +22,9 @@ export function ScreenFooter({
     <View
       style={[
         tw`${cn('px-6 py-4', {
-          'bg-black': withBackground,
+          'bg-surface dark:bg-surface-dark': withBackground,
           'shadow-lg': withShadow,
-          'border-t border-gray-800': withBorder,
+          'border-t border-border dark:border-border-dark': withBorder,
         })}`,
         style,
       ]}

--- a/packages/design-system/src/components/ScreenFooter/index.ts
+++ b/packages/design-system/src/components/ScreenFooter/index.ts
@@ -1,0 +1,1 @@
+export { ScreenFooter } from './ScreenFooter';

--- a/packages/design-system/src/components/Text/Text.tsx
+++ b/packages/design-system/src/components/Text/Text.tsx
@@ -29,7 +29,7 @@ const textVariants = cva({
       warning: 'text-warning dark:text-warning-dark',
       error: 'text-error dark:text-error-dark',
       text: 'text-text dark:text-text-dark',
-      textSecondary: 'text-text-secondary dark:text-text-secondary-dark',
+      textSecondary: 'text-secondary dark:text-secondary-dark',
       background: 'text-background dark:text-background-dark',
       border: 'text-border dark:text-border-dark',
       surface: 'text-surface dark:text-surface-dark',

--- a/packages/design-system/src/components/index.ts
+++ b/packages/design-system/src/components/index.ts
@@ -9,3 +9,4 @@ export * from './Input';
 export * from './Text';
 export * from './Icon';
 export * from './Progress';
+export * from './ScreenFooter';

--- a/packages/domain/src/auth/index.ts
+++ b/packages/domain/src/auth/index.ts
@@ -1,1 +1,2 @@
 export * from './auth.type';
+export * from './otp.error';

--- a/packages/domain/src/auth/otp.error.ts
+++ b/packages/domain/src/auth/otp.error.ts
@@ -1,0 +1,94 @@
+/**
+ * OTP 인증 관련 에러 코드
+ */
+
+import z from 'zod';
+
+// OTP 메시지 전송 에러 코드
+export enum OTPSendErrorCode {
+  /** 올바른 휴대폰 번호 형식이 아닙니다 */
+  INVALID_PHONE_FORMAT = 'INVALID_PHONE_FORMAT',
+  /** 휴대폰 번호는 3개월에 한 번만 변경 가능합니다 */
+  PHONE_CHANGE_NOT_ALLOWED = 'PHONE_CHANGE_NOT_ALLOWED',
+  /** 너무 빈번한 요청 */
+  REQUEST_TOO_FREQUENT = 'REQUEST_TOO_FREQUENT',
+  /** 하루 SMS 전송 제한 초과 */
+  RATE_LIMIT_EXCEEDED = 'RATE_LIMIT_EXCEEDED',
+}
+
+// OTP 인증 검증 에러 코드
+export enum OTPVerifyErrorCode {
+  /** 인증 번호가 일치하지 않습니다 */
+  INVALID_CODE = 'INVALID_CODE',
+  /** 인증 번호가 만료되었습니다 */
+  CODE_EXPIRED = 'CODE_EXPIRED',
+  /** 인증 시도 횟수 초과 */
+  TOO_MANY_REQUESTS = 'TOO_MANY_REQUESTS',
+  /** 이미 인증된 계정입니다 */
+  ALREADY_VERIFIED = 'ALREADY_VERIFIED',
+  /** 인증 요청 기록이 없습니다 */
+  RESOURCE_NOT_FOUND = 'RESOURCE_NOT_FOUND',
+}
+
+// 모든 OTP 에러 코드
+export type OTPErrorCode = OTPSendErrorCode | OTPVerifyErrorCode;
+
+/**
+ * OTP 에러 메시지 매핑
+ */
+export const OTP_ERROR_MESSAGES: Record<OTPErrorCode, string> = {
+  // OTP 전송 에러
+  [OTPSendErrorCode.INVALID_PHONE_FORMAT]: '올바른 휴대폰 번호 형식이 아닙니다.',
+  [OTPSendErrorCode.PHONE_CHANGE_NOT_ALLOWED]: '휴대폰 번호는 3개월에 한 번만 변경 가능합니다.',
+  [OTPSendErrorCode.REQUEST_TOO_FREQUENT]: '잠시 후 다시 시도해주세요.',
+  [OTPSendErrorCode.RATE_LIMIT_EXCEEDED]: '하루 SMS 전송 제한을 초과하였습니다. (5회 제한)',
+
+  // OTP 검증 에러
+  [OTPVerifyErrorCode.INVALID_CODE]: '인증 번호가 일치하지 않습니다.',
+  [OTPVerifyErrorCode.CODE_EXPIRED]: '인증 번호가 만료되었습니다. 다시 요청해주세요.',
+  [OTPVerifyErrorCode.TOO_MANY_REQUESTS]:
+    '인증 시도 횟수를 초과했습니다. 다시 인증번호를 요청해주세요.',
+  [OTPVerifyErrorCode.ALREADY_VERIFIED]: '이미 인증된 계정입니다.',
+  [OTPVerifyErrorCode.RESOURCE_NOT_FOUND]:
+    '인증 요청 기록이 없습니다. 먼저 인증번호를 요청해주세요.',
+};
+
+/**
+ * 에러 코드에서 사용자 친화적 메시지 추출
+ */
+export function getOTPErrorMessage(errorCode: OTPErrorCode, serverMessage?: string): string {
+  // 서버에서 제공한 메시지가 있으면 우선 사용
+  if (serverMessage) {
+    return serverMessage;
+  }
+  // 아니면 매핑된 기본 메시지 사용
+  return OTP_ERROR_MESSAGES[errorCode] || '알 수 없는 오류가 발생했습니다.';
+}
+
+/**
+ * 에러 메시지에서 남은 시도 횟수 추출
+ * @example "인증 번호가 일치하지 않습니다. (남은 시도: 4회)" -> 4
+ */
+export function extractRemainingAttempts(message: string): number | null {
+  const match = message.match(/남은 시도:\s*(\d+)회/);
+  return match ? parseInt(match[1], 10) : null;
+}
+
+/**
+ * 에러 메시지에서 다음 변경 가능일 추출
+ * @example "휴대폰 번호는 3개월에 한 번만 변경 가능합니다. (다음 변경 가능일: 2025-04-03)" -> "2025-04-03"
+ */
+export function extractNextAvailableDate(message: string): string | null {
+  const match = message.match(/다음 변경 가능일:\s*(\d{4}-\d{2}-\d{2})/);
+  return match ? match[1] : null;
+}
+
+/**
+ * OTP 코드 스키마 (6자리 숫자)
+ */
+export const OTPCodeSchema = z
+  .string()
+  .length(6, '6자리 인증번호를 입력해주세요.')
+  .regex(/^\d{6}$/, '인증번호는 숫자만 입력 가능합니다.');
+
+export type OTPCode = z.infer<typeof OTPCodeSchema>;

--- a/packages/domain/src/user/user.type.ts
+++ b/packages/domain/src/user/user.type.ts
@@ -12,4 +12,5 @@ export type User = z.infer<typeof User>;
 export interface UserProfile {
   user: User;
   subscription: Subscription;
+  isPhoneVerified: boolean;
 }

--- a/packages/domain/src/utils/PhoneNumber.ts
+++ b/packages/domain/src/utils/PhoneNumber.ts
@@ -14,45 +14,12 @@ import { z } from 'zod';
  * PhoneNumber.removeHyphens('010-1234-5678') // '01012345678'
  */
 export const PhoneNumber = {
-  /**
-   * 한국 휴대폰 번호 형식을 검증하는 Zod 스키마
-   *
-   * 지원 형식:
-   * - 010-XXXX-XXXX
-   *
-   * @example
-   * PhoneNumber.schema.parse('010-1234-5678') // ✅ 통과
-   * PhoneNumber.schema.parse('01012345678')   // ❌ 실패 (하이픈 없음)
-   * PhoneNumber.schema.parse('010-123-4567')  // ❌ 실패 (형식 불일치)
-   * PhoneNumber.schema.parse('02-123-4567')   // ❌ 실패 (지역번호)
-   */
   schema: z
     .string()
     .regex(/^(010)-\d{4}-\d{4}$/, '올바른 휴대폰 번호 형식이 아닙니다. (예: 010-1234-5678)'),
 
-  /**
-   * 하이픈 없는 휴대폰 번호를 하이픈이 있는 형식으로 변환
-   *
-   * @param phone - 하이픈 없는 휴대폰 번호 (예: "01012345678")
-   * @returns 하이픈이 포함된 휴대폰 번호 (예: "010-1234-5678")
-   *
-   * @example
-   * PhoneNumber.format('01012345678') // '010-1234-5678'
-   * PhoneNumber.format('1234') // '010-1234'
-   * PhoneNumber.format('12345678') // '010-1234-5678'
-   */
   format(phone: string): string {
-    // 입력 검증
-    if (!phone || typeof phone !== 'string') {
-      return '010-';
-    }
-
     const cleaned = phone.replace(/\D/g, '');
-
-    // 빈 문자열 처리
-    if (cleaned.length === 0) {
-      return '010-';
-    }
 
     // 010으로 시작하도록 보장
     const withPrefix = cleaned.startsWith('010') ? cleaned : `010${cleaned}`;
@@ -69,24 +36,9 @@ export const PhoneNumber = {
     }
   },
 
-  /**
-   * 휴대폰 번호에서 하이픈을 제거
-   *
-   * @param phone - 하이픈이 포함된 휴대폰 번호 (예: "010-1234-5678")
-   * @returns 하이픈이 제거된 휴대폰 번호 (예: "01012345678")
-   *
-   * @example
-   * PhoneNumber.removeHyphens('010-1234-5678') // '01012345678'
-   */
   removeHyphens(phone: string): string {
     return phone.replace(/-/g, '');
   },
 } as const;
 
-/**
- * PhoneNumber 스키마의 타입
- *
- * @example
- * const phone: PhoneNumberType = '010-1234-5678';
- */
 export type PhoneNumberType = z.infer<typeof PhoneNumber.schema>;

--- a/packages/domain/src/utils/PhoneNumber.ts
+++ b/packages/domain/src/utils/PhoneNumber.ts
@@ -1,0 +1,92 @@
+import { z } from 'zod';
+
+/**
+ * 한국 휴대폰 번호 유틸리티
+ *
+ * @example
+ * // Zod 스키마로 검증
+ * PhoneNumber.schema.parse('010-1234-5678') // ✅
+ *
+ * // 포맷팅
+ * PhoneNumber.format('01012345678') // '010-1234-5678'
+ *
+ * // 하이픈 제거
+ * PhoneNumber.removeHyphens('010-1234-5678') // '01012345678'
+ */
+export const PhoneNumber = {
+  /**
+   * 한국 휴대폰 번호 형식을 검증하는 Zod 스키마
+   *
+   * 지원 형식:
+   * - 010-XXXX-XXXX
+   *
+   * @example
+   * PhoneNumber.schema.parse('010-1234-5678') // ✅ 통과
+   * PhoneNumber.schema.parse('01012345678')   // ❌ 실패 (하이픈 없음)
+   * PhoneNumber.schema.parse('010-123-4567')  // ❌ 실패 (형식 불일치)
+   * PhoneNumber.schema.parse('02-123-4567')   // ❌ 실패 (지역번호)
+   */
+  schema: z
+    .string()
+    .regex(/^(010)-\d{4}-\d{4}$/, '올바른 휴대폰 번호 형식이 아닙니다. (예: 010-1234-5678)'),
+
+  /**
+   * 하이픈 없는 휴대폰 번호를 하이픈이 있는 형식으로 변환
+   *
+   * @param phone - 하이픈 없는 휴대폰 번호 (예: "01012345678")
+   * @returns 하이픈이 포함된 휴대폰 번호 (예: "010-1234-5678")
+   *
+   * @example
+   * PhoneNumber.format('01012345678') // '010-1234-5678'
+   * PhoneNumber.format('1234') // '010-1234'
+   * PhoneNumber.format('12345678') // '010-1234-5678'
+   */
+  format(phone: string): string {
+    // 입력 검증
+    if (!phone || typeof phone !== 'string') {
+      return '010-';
+    }
+
+    const cleaned = phone.replace(/\D/g, '');
+
+    // 빈 문자열 처리
+    if (cleaned.length === 0) {
+      return '010-';
+    }
+
+    // 010으로 시작하도록 보장
+    const withPrefix = cleaned.startsWith('010') ? cleaned : `010${cleaned}`;
+
+    // 최대 11자리까지만
+    const limited = withPrefix.slice(0, 11);
+
+    if (limited.length <= 3) {
+      return limited;
+    } else if (limited.length <= 7) {
+      return `${limited.slice(0, 3)}-${limited.slice(3)}`;
+    } else {
+      return `${limited.slice(0, 3)}-${limited.slice(3, 7)}-${limited.slice(7)}`;
+    }
+  },
+
+  /**
+   * 휴대폰 번호에서 하이픈을 제거
+   *
+   * @param phone - 하이픈이 포함된 휴대폰 번호 (예: "010-1234-5678")
+   * @returns 하이픈이 제거된 휴대폰 번호 (예: "01012345678")
+   *
+   * @example
+   * PhoneNumber.removeHyphens('010-1234-5678') // '01012345678'
+   */
+  removeHyphens(phone: string): string {
+    return phone.replace(/-/g, '');
+  },
+} as const;
+
+/**
+ * PhoneNumber 스키마의 타입
+ *
+ * @example
+ * const phone: PhoneNumberType = '010-1234-5678';
+ */
+export type PhoneNumberType = z.infer<typeof PhoneNumber.schema>;

--- a/packages/domain/src/utils/index.ts
+++ b/packages/domain/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './DateFromString';
+export * from './PhoneNumber';


### PR DESCRIPTION
## 요약

제품 신청 및 구독 변경 등 중요한 작업 수행 시 본인 확인을 위한 휴대폰 OTP 인증 시스템을 구현했습니다. 사용자는 휴대폰 번호로 인증번호를 받아 본인 인증을 완료할 수 있으며, 인증이 필요한 기능에는 자동으로 인증 게이트가 적용됩니다. 도메인 레이어부터 UI까지 전체 아키텍처를 체계적으로 구성하여 유지보수성과 확장성을 확보했습니다.

## 스크린샷

<table>
  <thead>
    <tr>
      <th rowspan="2"></th>
    </tr>
    <tr>
      <th>OTP 성공</th>
      <th>OTP 실패</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>Light</td>
      <td>
        <video
          src="https://github.com/user-attachments/assets/c359ff12-3b49-4f4b-b660-60c3972e3203"
          controls
          muted
          playsinline
          width="220"
        ></video>
      </td>
      <td>
        <video
          src="https://github.com/user-attachments/assets/4561d673-381b-42f4-aa97-6305abea0f6c"
          controls
          muted
          playsinline
          width="220"
        ></video>
      </td>
    </tr>
<tr>
      <td>Dark</td>
      <td>
        <video
          src="https://github.com/user-attachments/assets/c87f8835-23bc-4eff-a621-c5b92a719913"
          controls
          muted
          playsinline
          width="220"
        ></video>
      </td>
      <td>
        <video
          src="https://github.com/user-attachments/assets/3b5a0799-3bd8-499c-a8e6-f92fadd3de4e"
          controls
          muted
          playsinline
          width="220"
        ></video>
      </td>
    </tr>
  </tbody>
</table>

## 주요 변경사항

- 휴대폰 번호 입력 및 OTP 코드 검증 화면 구현
- 실시간 휴대폰 번호 포맷팅 (010-XXXX-XXXX 형식, 010 prefix 자동 적용)
- 커스텀 숫자 키패드 및 6자리 OTP 입력 컴포넌트 구현
- 타이머 기반 OTP 만료 관리 및 재전송 기능
- WithPhoneVerification HOC를 통한 기능 접근 제어
- 제품 신청 및 구독 변경 화면에 휴대폰 인증 연동
- 에러 처리 및 사용자 피드백 시스템

## 변경 내용

### 도메인 레이어

#### PhoneNumber 유틸리티
- **위치**: `packages/domain/src/utils/PhoneNumber.ts`
- **기능**:
  - 010-XXXX-XXXX 형식 Zod 스키마 검증
  - 실시간 하이픈 포맷팅 (입력 시 자동으로 하이픈 삽입)
  - 010 prefix 자동 적용 및 최대 11자리 제한
  - 하이픈 제거 유틸리티
- **특징**: "010-" 이하로 삭제되지 않도록 보호

#### OTP 에러 정의
- **위치**: `packages/domain/src/auth/otp.error.ts`
- **포함 내용**:
  - `OTPSendErrorCode`: 인증번호 전송 에러 (형식 오류, 빈번한 요청, 전송 제한 초과 등)
  - `OTPVerifyErrorCode`: 인증 검증 에러 (코드 불일치, 만료, 시도 횟수 초과 등)
  - 에러 메시지 매핑 및 추출 유틸리티 (남은 시도 횟수, 다음 변경 가능일)
  - 6자리 OTP 코드 검증 스키마

#### 사용자 프로필 타입 확장
- **위치**: `packages/domain/src/user/user.type.ts`
- **변경**: `UserProfile`에 `isPhoneVerified: boolean` 필드 추가

### API 레이어

#### OTP 전송 API
- **위치**: `packages/api/src/auth/postOTPMessage.ts`
- **엔드포인트**: `POST /auth/otp/send`
- **요청**: `{ phoneNumber: string }`
- **응답**: `{ expiresIn: number, canResendAfter: number }`

#### OTP 검증 API
- **위치**: `packages/api/src/auth/postOTPVerification.ts`
- **엔드포인트**: `POST /auth/otp/verify`
- **요청**: `{ phoneNumber: string, code: string, deviceId: string }`

#### 사용자 프로필 API 확장
- `getUserProfile`, `updateUserProfile` 응답에 `isPhoneVerified` 추가

### 디자인 시스템

#### ScreenFooter 컴포넌트
- **위치**: `packages/design-system/src/components/ScreenFooter/`
- **기능**: 화면 하단 고정 영역 컴포넌트
- **Props**: `withShadow`, `style`

#### Input 컴포넌트 개선
- **위치**: `packages/design-system/src/components/Input/Input.tsx`
- **추가 Props**: `returnKeyType`, `onSubmitEditing`
- **기능**: 키보드 완료 버튼으로 폼 제출 가능

### 훅 (Hooks)

#### useOTPTimer
- **위치**: `apps/mobile/src/features/auth/hooks/useOTPTimer.ts`
- **기능**:
  - OTP 만료 시간 카운트다운 (초 단위)
  - 재전송 대기 시간 관리
  - `startTimer`, `resetTimer` 함수 제공
- **최적화**: `useCallback`으로 불필요한 리렌더링 방지

#### useOTPVerification
- **위치**: `apps/mobile/src/features/auth/hooks/useOTPVerification.ts`
- **기능**:
  - OTP 전송/검증 API 호출 (React Query)
  - 에러 상태 및 남은 시도 횟수 관리
  - 성공/실패 콜백 처리
  - 프로필 스토어 업데이트 (`verifyPhone`)
- **에러 처리**: `console.error`로 예상치 못한 에러 로깅

### 화면 (Screens)

#### OTPRequestScreen
- **위치**: `apps/mobile/src/app/screens/auth/OTPRequestScreen.tsx`
- **기능**:
  - 휴대폰 번호 입력 (초기값 "010-")
  - 실시간 포맷팅 및 유효성 검증
  - 키보드 완료 버튼으로 OTP 전송
  - 에러 메시지 표시
- **UX**: "010-" 이하로 삭제 불가

#### OTPVerificationScreen
- **위치**: `apps/mobile/src/app/screens/auth/OTPVerificationScreen.tsx`
- **기능**:
  - 6자리 OTP 코드 입력 (커스텀 NumPad 사용)
  - 자동 검증 (6자리 입력 완료 시)
  - 타이머 표시 및 만료 처리
  - 재전송 버튼 (대기 시간 카운트다운)
- **UX**: 입력 완료 시 즉시 검증, 에러 발생 시 코드 자동 초기화

### UI 컴포넌트

#### NumPad
- **위치**: `apps/mobile/src/features/auth/components/NumPad.tsx`
- **기능**: 커스텀 숫자 키패드 (0-9, 삭제)
- **반응형**: `useWindowDimensions`로 다양한 기기 크기 대응
- **레이아웃**: 재전송 버튼을 고려한 동적 크기 계산

#### OTPCodeInput
- **위치**: `apps/mobile/src/features/auth/components/OTPCodeInput.tsx`
- **기능**: 6자리 OTP 입력 필드
- **UX**:
  - 개별 셀 포커스 상태 시각화
  - 자동 포커스 이동
  - 소프트 키보드 숨김 (NumPad 사용)
  - Backspace 키로 이전 셀로 이동

#### WithPhoneVerification (HOC)
- **위치**: `apps/mobile/src/features/auth/components/WithPhoneVerification.tsx`
- **기능**:
  - 휴대폰 인증 상태 확인
  - 미인증 시 Alert 표시 및 인증 화면 유도
  - `onPress` 이벤트 인터셉트 옵션
- **Props**: `message`, `onUnverified`, `interceptPress`

#### usePhoneVerification 훅
- **위치**: 동일 파일 내
- **기능**:
  - `isPhoneVerified` 상태 조회
  - `requirePhoneVerification`: 인증 필요 시 Alert 표시 및 boolean 반환
  - `navigateToPhoneVerification`: 인증 화면으로 이동

### 네비게이션 및 기능 연동

#### 네비게이션 설정
- **위치**: `apps/mobile/src/app/navigation/LoggedInNavigator.tsx`
- **추가 화면**: `OTPRequest`, `OTPVerification`
- **타입 정의**: `apps/mobile/src/app/navigation/types.ts`에 파라미터 타입 추가

#### ProductScreen 연동
- **위치**: `apps/mobile/src/app/screens/product/ProductScreen.tsx`
- **변경**: 신청 버튼을 `WithPhoneVerification`으로 감싸기
- **동작**: 미인증 시 신청 전 인증 화면으로 이동

#### SubscriptionChangeScreen 연동
- **위치**: `apps/mobile/src/app/screens/subscription/SubscriptionChangeScreen.tsx`
- **변경**: `usePhoneVerification` 훅 사용
- **동작**: 구독 변경 전 인증 상태 확인

### 상태 관리

#### 프로필 스토어 수정
- **위치**: `apps/mobile/src/features/user/store.ts`
- **추가**: `isPhoneVerified` 상태
- **액션**: `verifyPhone(isVerified: boolean)` - 인증 상태 업데이트
- **버그 수정**: `verfifyPhone` → `verifyPhone` 오타 수정

#### 사용자 훅 수정
- **위치**: `apps/mobile/src/features/user/hooks.ts`
- **추가**: `isPhoneVerified` export

### 설정

#### QueryKeys 추가
- **위치**: `apps/mobile/src/configs/queryClient/QueryKeys.ts`
- **추가**: OTP 관련 쿼리 키 정의

## 테스트

### 수동 테스트 가이드

#### OTP 전송 플로우
1. 제품 화면에서 신청 버튼 클릭 (미인증 상태)
2. Alert에서 "인증하기" 선택
3. OTPRequest 화면에서 휴대폰 번호 입력
4. "010-" 이하로 삭제되지 않는지 확인
5. 숫자 입력 시 실시간 하이픈 포맷팅 확인 (예: 010 → 010-1 → 010-12)
6. 키보드 완료 버튼 또는 "인증번호 받기" 버튼 클릭
7. OTPVerification 화면으로 이동 확인

#### OTP 검증 플로우
1. 6자리 인증번호 입력 (NumPad 사용)
2. 타이머 카운트다운 확인
3. 6자리 입력 완료 시 자동 검증 확인
4. 성공 시 "인증 완료" Alert 및 Home 화면 이동
5. 실패 시 에러 메시지 및 코드 초기화 확인

#### 재전송 기능
1. OTPVerification 화면에서 "재전송" 버튼 클릭
2. 대기 시간 동안 버튼 비활성화 확인
3. 대기 시간 경과 후 재전송 가능 확인
4. 재전송 후 타이머 재시작 확인

#### 에러 처리
1. 잘못된 인증번호 입력 → "인증 번호가 일치하지 않습니다" 메시지
2. 타이머 만료 후 검증 시도 → "만료되었습니다" 메시지
3. 하루 전송 제한 초과 → "하루 SMS 전송 제한을 초과하였습니다" 메시지

### 테스트 환경
- ✅ 로컬 환경에서 테스트 완료
- ✅ iOS 시뮬레이터에서 동작 확인
- ✅ Android 에뮬레이터에서 동작 확인
- ✅ 다양한 화면 크기에서 NumPad 반응형 레이아웃 확인

## 완료

- [x] 도메인 레이어 구현 (PhoneNumber 유틸리티, OTP 에러 정의)
- [x] API 레이어 구현 (OTP 전송/검증 엔드포인트)
- [x] 디자인 시스템 컴포넌트 추가 (ScreenFooter, Input 개선)
- [x] OTP 인증 훅 구현 (useOTPTimer, useOTPVerification)
- [x] OTP 인증 화면 구현 (OTPRequestScreen, OTPVerificationScreen)
- [x] UI 컴포넌트 구현 (NumPad, OTPCodeInput, WithPhoneVerification)
- [x] 네비게이션 설정 및 타입 정의
- [x] 제품 신청 화면 휴대폰 인증 연동
- [x] 구독 변경 화면 휴대폰 인증 연동
- [x] 프로필 스토어 확장 및 버그 수정
- [x] 에러 처리 및 로깅 추가
- [x] 성능 최적화 (useCallback)
- [x] 반응형 레이아웃 구현
